### PR TITLE
implement player upgrade tracking

### DIFF
--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -22,9 +22,10 @@ void AdditionalPylonsModule::onStart() {
 	BWAPI::Broodwar->setLocalSpeed(10);
 	BWAPI::Broodwar->setFrameSkip(0);
 
+	PlayerUpgrades::onStart();
 	Player::getPlayerInstance().onStart(BWAPI::Broodwar->self()->getRace());
 	Player::getEnemyInstance().onStart(BWAPI::Broodwar->enemy()->getRace());
-	PlayerUpgrades::onStart();
+	
 
 	Strategist::getInstance().onStart();
 }
@@ -38,6 +39,7 @@ void AdditionalPylonsModule::onFrame() {
 
 	BWEB::Map::draw();
 
+	PlayerUpgrades::onFrame();
 	Player::getPlayerInstance().onFrame();
 
 	Player::getPlayerInstance().displayInfo(400);

--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -24,6 +24,7 @@ void AdditionalPylonsModule::onStart() {
 
 	Player::getPlayerInstance().onStart(BWAPI::Broodwar->self()->getRace());
 	Player::getEnemyInstance().onStart(BWAPI::Broodwar->enemy()->getRace());
+	PlayerUpgrades::onStart();
 
 	Strategist::getInstance().onStart();
 }

--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -22,8 +22,8 @@ void AdditionalPylonsModule::onStart() {
 	BWAPI::Broodwar->setLocalSpeed(10);
 	BWAPI::Broodwar->setFrameSkip(0);
 
-	player.onStart(BWAPI::Broodwar->self()->getRace());
-	enemy.onStart(BWAPI::Broodwar->enemy()->getRace());
+	player.onStart(BWAPI::Broodwar->self());
+	enemy.onStart(BWAPI::Broodwar->enemy());
 
 	Strategist::getInstance().onStart();
 }
@@ -79,7 +79,7 @@ void AdditionalPylonsModule::onUnitCreate(BWAPI::Unit unit) {
 	if (unit->getPlayer() == BWAPI::Broodwar->self()) {
 		player.onUnitCreate(unit);
 	}
-	else if(unit->getPlayer() != BWAPI::Broodwar->neutral()){
+	else if(unit->getPlayer() != BWAPI::Broodwar->neutral()) {
 		enemy.onUnitCreate(unit);
 	}
 }
@@ -92,10 +92,7 @@ void AdditionalPylonsModule::onUnitDestroy(BWAPI::Unit unit) {
 		
 	if (unit->getPlayer() == BWAPI::Broodwar->self()) {
 		player.onUnitDestroy(unit);
-
-		if (unit->getType() == BWAPI::UnitTypes::Zerg_Overlord) {
-			Strategist::getInstance().decrementSupply();
-		}
+		Strategist::getInstance().adjustTotalSupply(-unit->getType().supplyProvided());
 	}
 	else if (unit->getPlayer() != BWAPI::Broodwar->neutral()) {
 		enemy.onUnitDestroy(unit);

--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -34,7 +34,7 @@ void AdditionalPylonsModule::onEnd(bool isWinner) {
 }
 
 void AdditionalPylonsModule::onFrame() {
-Strategist::getInstance().onFrame();
+	Strategist::getInstance().onFrame();
 
 	BWEB::Map::draw();
 

--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -22,8 +22,8 @@ void AdditionalPylonsModule::onStart() {
 	BWAPI::Broodwar->setLocalSpeed(10);
 	BWAPI::Broodwar->setFrameSkip(0);
 
-	Player::getPlayerInstance().onStart(BWAPI::Broodwar->self());
-	Player::getEnemyInstance().onStart(BWAPI::Broodwar->enemy());
+	Player::getPlayerInstance().onStart(BWAPI::Broodwar->self()->getRace());
+	Player::getEnemyInstance().onStart(BWAPI::Broodwar->enemy()->getRace());
 
 	Strategist::getInstance().onStart();
 }

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -2,32 +2,29 @@
 #include "../Strategist/Strategist.h"
 
 //Auto assigns this player's race and sets enemies race to unknown
-void Player::onStart(BWAPI::Player player) {
+void Player::onStart(BWAPI::Race race) {
 	this->armyUnits.clear();
 	this->nonArmyUnits.clear();
 	this->buildingUnits.clear();
 	this->allUnits.clear();
-	this->player = player;
-	this->playerRace = player->getRace();
+	this->playerRace = race;
 }
 
 void Player::onFrame() {
 
-	if (this->player == BWAPI::Broodwar->self()) {
-		for (auto& [key, value] : this->armyUnits) {
-			value->onFrame();
-			value->displayInfo();
-		}
+	for (auto& [key, value] : this->armyUnits) {
+		value->onFrame();
+		value->displayInfo();
+	}
 
-		for (auto& [key, value] : this->nonArmyUnits) {
-			value->onFrame();
-			value->displayInfo();
-		}
+	for (auto& [key, value] : this->nonArmyUnits) {
+		value->onFrame();
+		value->displayInfo();
+	}
 
-		for (auto& [key, value] : this->buildingUnits) {
-			value->onFrame();
-			value->displayInfo();
-		}
+	for (auto& [key, value] : this->buildingUnits) {
+		value->onFrame();
+		value->displayInfo();
 	}
 }
 

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -8,11 +8,9 @@ void Player::onStart(BWAPI::Player player) {
 	this->allUnits.clear();
 	this->player = player;
 	this->playerRace = player->getRace();
-	this->upgrades.onStart(player);
 }
 
 void Player::onFrame() {
-	this->upgrades.onFrame();
 
 	if (this->player == BWAPI::Broodwar->self()) {
 		for (auto& [key, value] : this->armyUnits) {
@@ -145,3 +143,21 @@ std::unordered_map<int, BWAPI::Unit> Player::getUnitsByType(BWAPI::UnitType type
 
 	return specUnits;
 }
+
+namespace PlayerUpgrades {
+	std::map<BWAPI::Player, std::shared_ptr<Upgrades>> playerUpgradesMap;
+
+	void onFrame() {
+		for (const auto& playerUpgrades : playerUpgradesMap)
+			playerUpgrades.second.get()->onFrame();
+	}
+
+	std::shared_ptr<Upgrades> getPlayerUpgrades(BWAPI::Player player) {
+		auto upgradesIter = playerUpgradesMap.find(player);
+		if (upgradesIter != playerUpgradesMap.end())
+			return upgradesIter->second;
+		auto upgrades = std::make_shared<Upgrades>(player);
+		playerUpgradesMap[player] = upgrades;
+		return upgrades;
+	}
+};

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -159,6 +159,10 @@ std::map<BWAPI::UnitType, int> Player::getUnitCount() {
 namespace PlayerUpgrades {
 	std::map<BWAPI::Player, std::shared_ptr<Upgrades>> playerUpgradesMap;
 
+    void onStart() {
+        playerUpgradesMap.clear();
+    }
+
 	void onFrame() {
 		for (const auto& playerUpgrades : playerUpgradesMap)
 			playerUpgrades.second.get()->onFrame();

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -5,18 +5,12 @@
 
 #include <BWAPI.h>
 
+#include "./Upgrades/Upgrades.h"
 #include "../Units/Units.h"
 
 class Player {
-private:
-    std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
-    std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
-    std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
-    std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
-    BWAPI::Race playerRace;
-
 public:
-    void onStart(BWAPI::Race race);
+    void onStart(BWAPI::Player player);
     void onFrame();
     void onNukeDetect(BWAPI::Position target);
     void onUnitEvade(BWAPI::Unit unit);
@@ -29,12 +23,14 @@ public:
     void onUnitDiscover(BWAPI::Unit unit);
     BWAPI::Race getRace() { return this->playerRace; }
     void displayInfo(int x);
+
     /*
     Returns a map of all units in a specified area
     @returns
         @retval std::unordered_map<int, BWAPI::Unit> map of units in given area
     */
     std::unordered_map<int, BWAPI::Unit> getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight);
+
     /*
     Returns a map of all units of a specified type
     Returns all units if type is BWAPI::UnitTypes::Unknown
@@ -42,6 +38,71 @@ public:
         @retval std::unordered_map<int, BWAPI::Unit> map of units by unit type
     */
     std::unordered_map<int, BWAPI::Unit> getUnitsByType(BWAPI::UnitType type);
+
+	/*
+	Returns the damage of the specified BWAPI::WeaponType
+	@returns
+		@retval int of the weapon's damage
+	*/
+	int getWeaponDamage(BWAPI::WeaponType weapon) { this->upgrades.getWeaponDamage(weapon); };
+
+	/*
+	Returns the range of the specified BWAPI::WeaponType
+	@returns
+		@retval int of the weapon's range
+	*/
+	int getWeaponRange(BWAPI::WeaponType weapon) { this->upgrades.getWeaponRange(weapon); };
+
+	/*
+	Returns the weapon cooldown of the specified BWAPI::UnitType
+	@returns
+		@retval int of the unit's weapon cooldown
+	*/
+	int getUnitCooldown(BWAPI::UnitType type) { this->upgrades.getUnitCooldown(type); };
+
+	/*
+	Returns the armor of the specified BWAPI::UnitType
+	@returns
+		@retval int of the unit's armor
+	*/
+	int getUnitArmor(BWAPI::UnitType type) { this->upgrades.getUnitArmor(type); };
+
+	/*
+	Returns the sight range of the specified BWAPI::UnitType
+	@returns
+		@retval int of the unit's sight range
+	*/
+	int getUnitSight(BWAPI::UnitType type) { this->upgrades.getUnitSight(type); };
+
+	/*
+	Returns the maximum movement speed of the specified BWAPI::UnitType
+	@returns
+		@retval int of the unit's maximum movement speed
+	*/
+	double getUnitSpeed(BWAPI::UnitType type) { this->upgrades.getUnitSpeed(type); };
+
+	/*
+	Returns if the specified BWAPI::TechType has been researched
+	@returns
+		@retval bool on if the specified player has researched the specified tech
+	*/
+	bool hasResearchedTech(BWAPI::TechType tech) { this->upgrades.hasResearchedTech(tech); };
+
+	/*
+	Returns the upgrade level of the specified BWAPI::UpgradeType
+	@returns
+		@retval int of the upgrade's level
+	*/
+	int getUpgradeLevel(BWAPI::UpgradeType upgrade) { this->upgrades.getUpgradeLevel(upgrade); };
+
+protected:
+    Upgrades upgrades = Upgrades();
+    std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
+    std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
+    std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
+    std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
+    BWAPI::Player player = nullptr;
+    BWAPI::Race playerRace;
 };
 
 static Player player = Player();

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -77,6 +77,7 @@ protected:
 };
 
 namespace PlayerUpgrades {
+    void onStart();
     void onFrame();
     /*
     Returns an Upgrades tracking class pointer based on the BWAPI::Player given

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -59,70 +59,23 @@ public:
     */
     std::unordered_map<int, BWAPI::Unit> getUnitsByType(BWAPI::UnitType type);
 
-	/*
-	Returns the damage of the specified BWAPI::WeaponType
-	@returns
-		@retval int of the weapon's damage
-	*/
-	int getWeaponDamage(BWAPI::WeaponType weapon) { this->upgrades.getWeaponDamage(weapon); };
-
-	/*
-	Returns the range of the specified BWAPI::WeaponType
-	@returns
-		@retval int of the weapon's range
-	*/
-	int getWeaponRange(BWAPI::WeaponType weapon) { this->upgrades.getWeaponRange(weapon); };
-
-	/*
-	Returns the weapon cooldown of the specified BWAPI::UnitType
-	@returns
-		@retval int of the unit's weapon cooldown
-	*/
-	int getUnitCooldown(BWAPI::UnitType type) { this->upgrades.getUnitCooldown(type); };
-
-	/*
-	Returns the armor of the specified BWAPI::UnitType
-	@returns
-		@retval int of the unit's armor
-	*/
-	int getUnitArmor(BWAPI::UnitType type) { this->upgrades.getUnitArmor(type); };
-
-	/*
-	Returns the sight range of the specified BWAPI::UnitType
-	@returns
-		@retval int of the unit's sight range
-	*/
-	int getUnitSight(BWAPI::UnitType type) { this->upgrades.getUnitSight(type); };
-
-	/*
-	Returns the maximum movement speed of the specified BWAPI::UnitType
-	@returns
-		@retval int of the unit's maximum movement speed
-	*/
-	double getUnitSpeed(BWAPI::UnitType type) { this->upgrades.getUnitSpeed(type); };
-
-	/*
-	Returns if the specified BWAPI::TechType has been researched
-	@returns
-		@retval bool on if the specified player has researched the specified tech
-	*/
-	bool hasResearchedTech(BWAPI::TechType tech) { this->upgrades.hasResearchedTech(tech); };
-
-	/*
-	Returns the upgrade level of the specified BWAPI::UpgradeType
-	@returns
-		@retval int of the upgrade's level
-	*/
-	int getUpgradeLevel(BWAPI::UpgradeType upgrade) { this->upgrades.getUpgradeLevel(upgrade); };
-
 protected:
     Player() = default;
 
-    Upgrades upgrades = Upgrades();
     std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
     std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
     std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
     std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
     BWAPI::Player player = nullptr;
     BWAPI::Race playerRace;
+};
+
+namespace PlayerUpgrades {
+    void onFrame();
+    /*
+    Returns an Upgrades tracking class pointer based on the BWAPI::Player given
+    @returns
+        @retval std::shared_ptr<Upgrades> for the BWAPI::Player given
+    */
+    std::shared_ptr<Upgrades> getPlayerUpgrades(BWAPI::Player player);
 };

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -30,7 +30,7 @@ public:
         static Player instance;
         return instance;
     }
-    void onStart(BWAPI::Player player);
+    void onStart(BWAPI::Race race);
     void onFrame();
     void onNukeDetect(BWAPI::Position target);
     void onUnitEvade(BWAPI::Unit unit);
@@ -73,7 +73,6 @@ protected:
     std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
     std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
     std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
-    BWAPI::Player player = nullptr;
     BWAPI::Race playerRace;
 };
 

--- a/src/Players/Upgrades/Upgrades.cpp
+++ b/src/Players/Upgrades/Upgrades.cpp
@@ -1,6 +1,6 @@
 #include "./Upgrades.h"
 
-void Upgrades::onStart(BWAPI::Player _player) {
+Upgrades::Upgrades(BWAPI::Player _player) {
 	this->player = _player;
 	this->weaponDamage.clear();
 	this->weaponRange.clear();

--- a/src/Players/Upgrades/Upgrades.cpp
+++ b/src/Players/Upgrades/Upgrades.cpp
@@ -127,7 +127,7 @@ double Upgrades::getUnitSpeed(BWAPI::UnitType type) {
 bool Upgrades::hasResearchedTech(BWAPI::TechType tech) {
 	auto techIter = this->researchedTech.find(tech);
 	if (techIter != this->researchedTech.end())
-		return true;
+		return techIter->second;
 	bool researched = this->player->hasResearched(tech);
 	this->researchedTech[tech] = researched;
 	return researched;

--- a/src/Players/Upgrades/Upgrades.cpp
+++ b/src/Players/Upgrades/Upgrades.cpp
@@ -1,0 +1,143 @@
+#include "./Upgrades.h"
+
+void Upgrades::onStart(BWAPI::Player _player) {
+	this->player = _player;
+	this->weaponDamage.clear();
+	this->weaponRange.clear();
+	this->unitCooldown.clear();
+	this->unitSpeed.clear();
+	this->unitArmor.clear();
+	this->unitSight.clear();
+	this->researchedTech.clear();
+	this->upgradeLevel.clear();
+};
+
+void Upgrades::onFrame() {
+	// update all previously checked weapon damages
+	for (auto& [key, value] : this->weaponDamage) {
+		auto damage = this->player->damage(key);
+		if (damage != value)
+			value = damage;
+	}
+
+	// update all previously checked weapon ranges
+	for (auto& [key, value] : this->weaponRange) {
+		auto range = this->player->weaponMaxRange(key);
+		if (range != value)
+			value = range;
+	}
+
+	// update all previously checked unit weapon cooldowns
+	for (auto& [key, value] : this->unitCooldown) {
+		auto cooldown = this->player->weaponDamageCooldown(key);
+		if (cooldown != value)
+			value = cooldown;
+	}
+
+	// update all previously checked unit weapon cooldowns
+	for (auto& [key, value] : this->unitArmor) {
+		auto armor = this->player->armor(key);
+		if (armor != value)
+			value = armor;
+	}
+
+	// update all previously checked unit sight ranges
+	for (auto& [key, value] : this->unitSight) {
+		auto sight = this->player->sightRange(key);
+		if (sight != value)
+			value = sight;
+	}
+
+	// update all previously checked unit max speeds
+	for (auto& [key, value] : this->unitSpeed) {
+		auto speed = this->player->topSpeed(key);
+		if (speed != value)
+			value = speed;
+	}
+
+	// update all previously checked tech researched statuses
+	for (auto& [key, value] : this->researchedTech) {
+		auto researched = this->player->hasResearched(key);
+		if (researched != value)
+			value = researched;
+	}
+
+	// update all previously checked upgrade levels
+	for (auto& [key, value] : this->upgradeLevel) {
+		auto level = this->player->getUpgradeLevel(key);
+		if (level != value)
+			value = level;
+	}
+}
+
+int Upgrades::getWeaponDamage(BWAPI::WeaponType weapon) {
+	auto damageIter = this->weaponDamage.find(weapon);
+	if (damageIter != this->weaponDamage.end())
+		return damageIter->second;
+	int damage = this->player->damage(weapon);
+	this->weaponDamage[weapon] = damage;
+	return damage;
+}
+
+int Upgrades::getWeaponRange(BWAPI::WeaponType weapon) {
+	auto rangeIter = this->weaponRange.find(weapon);
+	if (rangeIter != this->weaponRange.end())
+		return rangeIter->second;
+	int range = this->player->weaponMaxRange(weapon);
+	this->weaponRange[weapon] = range;
+	return range;
+}
+
+int Upgrades::getUnitCooldown(BWAPI::UnitType type) {
+	auto cooldownIter = this->unitCooldown.find(type);
+	if (cooldownIter != this->unitCooldown.end())
+		return cooldownIter->second;
+	int cooldown = this->player->weaponDamageCooldown(type);
+	this->unitCooldown[type] = cooldown;
+	return cooldown;
+}
+
+int Upgrades::getUnitArmor(BWAPI::UnitType type) {
+	auto armorIter = this->unitArmor.find(type);
+	if (armorIter != this->unitArmor.end())
+		return armorIter->second;
+	int armor = this->player->armor(type);
+	this->unitArmor[type] = armor;
+	return armor;
+}
+
+int Upgrades::getUnitSight(BWAPI::UnitType type) {
+	auto sightIter = this->unitSight.find(type);
+	if (sightIter != this->unitSight.end())
+		return sightIter->second;
+	int sight = this->player->sightRange(type);
+	this->unitSight[type] = sight;
+	return sight;
+}
+
+double Upgrades::getUnitSpeed(BWAPI::UnitType type) {
+	auto speedIter = this->unitSpeed.find(type);
+	if (speedIter != this->unitSpeed.end())
+		return speedIter->second;
+	double speed = this->player->topSpeed(type);
+	this->unitSpeed[type] = speed;
+	return speed;
+}
+
+bool Upgrades::hasResearchedTech(BWAPI::TechType tech) {
+	auto techIter = this->researchedTech.find(tech);
+	if (techIter != this->researchedTech.end())
+		return true;
+	bool researched = this->player->hasResearched(tech);
+	this->researchedTech[tech] = researched;
+	return researched;
+}
+
+int Upgrades::getUpgradeLevel(BWAPI::UpgradeType upgrade) {
+	auto upgradeIter = this->upgradeLevel.find(upgrade);
+	if (upgradeIter != this->upgradeLevel.end())
+		return upgradeIter->second;
+	int level = this->player->getUpgradeLevel(upgrade);
+	this->upgradeLevel[upgrade] = level;
+	return level;
+}

--- a/src/Players/Upgrades/Upgrades.h
+++ b/src/Players/Upgrades/Upgrades.h
@@ -5,9 +5,8 @@
 
 class Upgrades {
 public:
-	Upgrades() {};
+	Upgrades(BWAPI::Player _player);
 
-	void onStart(BWAPI::Player _player);
 	void onFrame();
 
 	/*

--- a/src/Players/Upgrades/Upgrades.h
+++ b/src/Players/Upgrades/Upgrades.h
@@ -1,0 +1,79 @@
+#pragma once
+#include <map>
+
+#include <BWAPI.h>
+
+class Upgrades {
+public:
+	Upgrades() {};
+
+	void onStart(BWAPI::Player _player);
+	void onFrame();
+
+	/*
+	Returns the damage of the specified BWAPI::WeaponType for the specified player
+	@returns
+		@retval int of the weapon's damage
+	*/
+	int getWeaponDamage(BWAPI::WeaponType weapon);
+
+	/*
+	Returns the range of the specified BWAPI::WeaponType for the specified player
+	@returns
+		@retval int of the weapon's range
+	*/
+	int getWeaponRange(BWAPI::WeaponType weapon);
+
+	/*
+	Returns the weapon cooldown of the specified BWAPI::UnitType for the specified player
+	@returns
+		@retval int of the unit's weapon cooldown
+	*/
+	int getUnitCooldown(BWAPI::UnitType type);
+
+	/*
+	Returns the armor of the specified BWAPI::UnitType for the specified player
+	@returns
+		@retval int of the unit's armor
+	*/
+	int getUnitArmor(BWAPI::UnitType type);
+
+	/*
+	Returns the sight range of the specified BWAPI::UnitType for the specified player
+	@returns
+		@retval int of the unit's sight range
+	*/
+	int getUnitSight(BWAPI::UnitType type);
+
+	/*
+	Returns the maximum movement speed of the specified BWAPI::UnitType for the specified player
+	@returns
+		@retval int of the unit's maximum movement speed
+	*/
+	double getUnitSpeed(BWAPI::UnitType type);
+
+	/*
+	Returns if the specified BWAPI::TechType has been researched by the specified player
+	@returns
+		@retval bool on if the specified player has researched the specified tech
+	*/
+	bool hasResearchedTech(BWAPI::TechType tech);
+
+	/*
+	Returns the upgrade level of the specified BWAPI::UpgradeType for the specified player
+	@returns
+		@retval int of the upgrade's level
+	*/
+	int getUpgradeLevel(BWAPI::UpgradeType upgrade);
+
+protected:
+	BWAPI::Player player = nullptr;
+	std::map<BWAPI::WeaponType, int> weaponDamage;
+	std::map<BWAPI::WeaponType, int> weaponRange;
+	std::map<BWAPI::UnitType, int> unitCooldown;
+	std::map<BWAPI::UnitType, double> unitSpeed;
+	std::map<BWAPI::UnitType, int> unitArmor;
+	std::map<BWAPI::UnitType, int> unitSight;
+	std::map<BWAPI::TechType, bool> researchedTech;
+	std::map<BWAPI::UpgradeType, int> upgradeLevel;
+};

--- a/src/Strategist/Strategist.cpp
+++ b/src/Strategist/Strategist.cpp
@@ -7,54 +7,46 @@
 
 void Strategist::onStart() {
     // Get initial gamestate information
-    supply_total = BWAPI::Broodwar->self()->supplyTotal();
-    chooseOpeningBuildOrder();
+    this->totalSupply = BWAPI::Broodwar->self()->supplyTotal();
+    this->chooseOpeningBuildOrder();
 }
 
 void Strategist::onFrame() {
     // Check if we need to add something to the queue
-    if (!build_order_queue.empty()) {
-        updateUnitQueue();
+    if (!this->startingBuildQueue.empty()) {
+        this->updateUnitQueue();
     }
-}
-
-void Strategist::incrementSupply() {
-    supply_total += 16; // supply provided by an overlord
-}
-
-void Strategist::decrementSupply() {
-    supply_total -= 16; // supply provided by an overlord, should trigger on overlord death.
 }
 
 void Strategist::determineMapSize() {
     // Need to figure out how we want to determine this, or if we even want to determine it in the strategist.
-    map_size = smallest;
+    this->mapSize = MapSize::smallest;
 }
 
 std::optional<BWAPI::UnitType> Strategist::getUnitOrder(BWAPI::UnitType type) {
     std::optional<BWAPI::UnitType> unit = std::nullopt;
 
-    switch (type) {
-    case BWAPI::UnitTypes::Zerg_Larva: 
-        if (!larva_queue.empty()) {
-            unit = larva_queue.front(); 
-            larva_queue.pop();
+    auto buildIter = this->buildOrders.find(type);
+    if (buildIter != this->buildOrders.end()) {
+        if (buildIter->second.size()) {
+            unit = buildIter->second.front();
+            buildIter->second.pop();
         }
-        break;
-    case BWAPI::UnitTypes::Zerg_Drone:
-        if (!drone_queue.empty()) {
-            unit = drone_queue.front();
-            drone_queue.pop();
-        }
-        break;
-    case BWAPI::UnitTypes::Zerg_Hatchery: 
-        if (!hatchery_queue.empty()) {
-            unit = hatchery_queue.front(); 
-            hatchery_queue.pop();
-        }
-        break;
     }
     return unit;
+}
+
+std::optional<BWAPI::UpgradeType> Strategist::getUnitUpgradeOrder(BWAPI::UnitType type) {
+    std::optional<BWAPI::UpgradeType> upgrade = std::nullopt;
+
+    auto upgradeIter = this->upgradeOrders.find(type);
+    if (upgradeIter != this->upgradeOrders.end()) {
+        if (upgradeIter->second.size()) {
+            upgrade = upgradeIter->second.front();
+            upgradeIter->second.pop();
+        }
+    }
+    return upgrade;
 }
 
 void Strategist::chooseOpeningBuildOrder() {
@@ -65,28 +57,28 @@ void Strategist::chooseOpeningBuildOrder() {
 
     switch (enemy.getRace()) {
     case BWAPI::Races::Protoss:
-        switch (map_size) {
-        case smallest: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_smallest); break;
-        case medium: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_medium); break;
-        case large: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_large); break;
+        switch (this->mapSize) {
+        case MapSize::smallest: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_smallest); break;
+        case MapSize::medium: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_medium); break;
+        case MapSize::large: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(protoss_large); break;
         }
-    case BWAPI::Races::Terran: 
-        switch (map_size) {
-        case smallest: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_smallest); break;
-        case medium: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_medium); break;
-        case large: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_large); break;
+    case BWAPI::Races::Terran:
+        switch (this->mapSize) {
+        case MapSize::smallest: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_smallest); break;
+        case MapSize::medium: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_medium); break;
+        case MapSize::large: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(terran_large); break;
         }
     case BWAPI::Races::Zerg:
-        switch (map_size) {
-        case smallest: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_smallest); break;
-        case medium: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_medium); break;
-        case large: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_large); break;
+        switch (this->mapSize) {
+        case MapSize::smallest: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_smallest); break;
+        case MapSize::medium: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_medium); break;
+        case MapSize::large: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(zerg_large); break;
         }
     default:
-        switch (map_size) {
-        case smallest: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_smallest); break;
-        case medium: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_medium); break;
-        case large: build_order_queue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_large); break;
+        switch (this->mapSize) {
+        case MapSize::smallest: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_smallest); break;
+        case MapSize::medium: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_medium); break;
+        case MapSize::large: this->startingBuildQueue = std::queue<std::pair<BWAPI::UnitType, int>>(unknown_large); break;
         }
     }
 }
@@ -94,28 +86,28 @@ void Strategist::chooseOpeningBuildOrder() {
 void Strategist::updateUnitQueue() {
     // Need to track the amount of gas / minerals spent each frame in order to be able to queue multiple units on a single frame
     int frame_supply_used = 0;
+    auto order = this->startingBuildQueue.front();
 
-    while(!build_order_queue.empty() && 
-        ((BWAPI::Broodwar->self()->gatheredGas() - this->gas_spent) >= build_order_queue.front().first.gasPrice()) && 
-        ((BWAPI::Broodwar->self()->gatheredMinerals() - this->minerals_spent) >= build_order_queue.front().first.mineralPrice()) &&
-        ((BWAPI::Broodwar->self()->supplyUsed() + frame_supply_used) >= build_order_queue.front().second)) {
-        // Sufficient minerals, gas, and proper supply to build the unit
+    // Sufficient minerals, gas, and proper supply to build the unit
+    while(!this->startingBuildQueue.empty() &&
+        ((BWAPI::Broodwar->self()->gatheredGas() - this->spentGas) >= order.first.gasPrice()) &&
+        ((BWAPI::Broodwar->self()->gatheredMinerals() - this->spentMinerals) >= order.first.mineralPrice()) &&
+        ((BWAPI::Broodwar->self()->supplyUsed() + frame_supply_used) >= order.second)) {
+        
+        if (this->buildOrders.find(order.first.whatBuilds().first) == this->buildOrders.end())
+            this->buildOrders[order.first.whatBuilds().first] = std::queue<BWAPI::UnitType>{};
+        this->buildOrders[order.first.whatBuilds().first].push(order.first);
 
-        switch(build_order_queue.front().first.whatBuilds().first) {
-            case BWAPI::UnitTypes::Zerg_Larva: larva_queue.push(build_order_queue.front().first); break;
-            case BWAPI::UnitTypes::Zerg_Drone: drone_queue.push(build_order_queue.front().first); break;
-            case BWAPI::UnitTypes::Zerg_Hatchery: hatchery_queue.push(build_order_queue.front().first); break;
-        }
-        if (build_order_queue.front().first.supplyProvided() > 0) {
-            incrementSupply();
-        }
+        this->adjustTotalSupply(order.first.supplyProvided());
+
         // update spent minerals + gas + supply
-        minerals_spent += build_order_queue.front().first.mineralPrice();
-        gas_spent += build_order_queue.front().first.gasPrice();
+        this->spentMinerals += order.first.mineralPrice();
+        this->spentGas += order.first.gasPrice();
 
-        frame_supply_used += (build_order_queue.front().first == BWAPI::UnitTypes::Zerg_Zergling) ? (build_order_queue.front().first.supplyRequired() * 2) : build_order_queue.front().first.supplyRequired();
+        frame_supply_used += (order.first == BWAPI::UnitTypes::Zerg_Zergling) ? (order.first.supplyRequired() * 2) : order.first.supplyRequired();
 
         // Pop from build_order_queue
-        build_order_queue.pop();
+        this->startingBuildQueue.pop();
+        order = this->startingBuildQueue.front();
     }
 }

--- a/src/Strategist/Strategist.cpp
+++ b/src/Strategist/Strategist.cpp
@@ -86,28 +86,26 @@ void Strategist::chooseOpeningBuildOrder() {
 void Strategist::updateUnitQueue() {
     // Need to track the amount of gas / minerals spent each frame in order to be able to queue multiple units on a single frame
     int frame_supply_used = 0;
-    auto order = this->startingBuildQueue.front();
 
     // Sufficient minerals, gas, and proper supply to build the unit
     while(!this->startingBuildQueue.empty() &&
-        ((BWAPI::Broodwar->self()->gatheredGas() - this->spentGas) >= order.first.gasPrice()) &&
-        ((BWAPI::Broodwar->self()->gatheredMinerals() - this->spentMinerals) >= order.first.mineralPrice()) &&
-        ((BWAPI::Broodwar->self()->supplyUsed() + frame_supply_used) >= order.second)) {
+        ((BWAPI::Broodwar->self()->gatheredGas() - this->spentGas) >= this->startingBuildQueue.front().first.gasPrice()) &&
+        ((BWAPI::Broodwar->self()->gatheredMinerals() - this->spentMinerals) >= this->startingBuildQueue.front().first.mineralPrice()) &&
+        ((BWAPI::Broodwar->self()->supplyUsed() + frame_supply_used) >= this->startingBuildQueue.front().second)) {
         
-        if (this->buildOrders.find(order.first.whatBuilds().first) == this->buildOrders.end())
-            this->buildOrders[order.first.whatBuilds().first] = std::queue<BWAPI::UnitType>{};
-        this->buildOrders[order.first.whatBuilds().first].push(order.first);
+        if (this->buildOrders.find(this->startingBuildQueue.front().first.whatBuilds().first) == this->buildOrders.end())
+            this->buildOrders[this->startingBuildQueue.front().first.whatBuilds().first] = std::queue<BWAPI::UnitType>{};
+        this->buildOrders[this->startingBuildQueue.front().first.whatBuilds().first].push(this->startingBuildQueue.front().first);
 
-        this->adjustTotalSupply(order.first.supplyProvided());
+        this->adjustTotalSupply(this->startingBuildQueue.front().first.supplyProvided());
 
         // update spent minerals + gas + supply
-        this->spentMinerals += order.first.mineralPrice();
-        this->spentGas += order.first.gasPrice();
+        this->spentMinerals += this->startingBuildQueue.front().first.mineralPrice();
+        this->spentGas += this->startingBuildQueue.front().first.gasPrice();
 
-        frame_supply_used += (order.first == BWAPI::UnitTypes::Zerg_Zergling) ? (order.first.supplyRequired() * 2) : order.first.supplyRequired();
+        frame_supply_used += (this->startingBuildQueue.front().first == BWAPI::UnitTypes::Zerg_Zergling) ? (this->startingBuildQueue.front().first.supplyRequired() * 2) : this->startingBuildQueue.front().first.supplyRequired();
 
         // Pop from build_order_queue
         this->startingBuildQueue.pop();
-        order = this->startingBuildQueue.front();
     }
 }

--- a/src/Strategist/Strategist.h
+++ b/src/Strategist/Strategist.h
@@ -1,9 +1,11 @@
 #pragma once
-#include <BWAPI.h>
+#include <map>
 #include <queue>
 #include <optional>
 
-enum MapSize { smallest, medium, large };
+#include <BWAPI.h>
+
+enum class MapSize { smallest, medium, large };
 
 class Strategist {
 public:
@@ -18,16 +20,21 @@ public:
 
     void onStart();
     void onFrame();
-    void incrementSupply();
-    void decrementSupply();
+    void adjustTotalSupply(int supply) { this->totalSupply += supply; }
 
     /*
-    Returns the next build order by the requesters unit type, if there is one
+    Returns the next build order by the requesters BWAPI::UnitType, if there is one
     @returns
         @retval std::optional<BWAPI::UnitType>
     */
     std::optional<BWAPI::UnitType> getUnitOrder(BWAPI::UnitType type);
     
+    /*
+    Returns the next upgrade order by the requesters BWAPI::UnitType, if there is one
+    @returns
+        @retval std::optional<BWAPI::UpgradeType>
+    */
+    std::optional<BWAPI::UpgradeType> getUnitUpgradeOrder(BWAPI::UnitType type);
         
 private:
     Strategist() = default;
@@ -36,15 +43,15 @@ private:
     void chooseOpeningBuildOrder();
     void updateUnitQueue();
 
-    int minerals_spent = 0;
-    int gas_spent = 0;
-    int supply_total;
-  
-    std::queue<BWAPI::UnitType> larva_queue;
-    std::queue<BWAPI::UnitType> drone_queue;
-    std::queue<BWAPI::UnitType> hatchery_queue;
+    int spentMinerals = 0;
+    int spentGas = 0;
+    int totalSupply = 0;
 
-    MapSize map_size;
+    std::map<BWAPI::UnitType, std::queue<BWAPI::UnitType>> buildOrders;
+    std::map<BWAPI::UnitType, std::queue<BWAPI::UpgradeType>> upgradeOrders;
+    std::map<BWAPI::UnitType, std::queue<BWAPI::TechType>> researchOrders;
 
-    std::queue<std::pair<BWAPI::UnitType, int>> build_order_queue;
+    MapSize mapSize = MapSize::smallest;
+
+    std::queue<std::pair<BWAPI::UnitType, int>> startingBuildQueue;
 };

--- a/src/Units/BuildingWrappers/BuildingWrapper.cpp
+++ b/src/Units/BuildingWrappers/BuildingWrapper.cpp
@@ -1,26 +1,37 @@
 #include "./BuildingWrapper.h"
 #include "../../Strategist/Strategist.h"
 
-void BuildingWrapper::onFrame()
-{
-	//if the unit is not busy and doesnt have a job
-	if (!this->isBusy() && this->buildOrder == BWAPI::UnitTypes::Unknown)
-	{//get order from strategist
+void BuildingWrapper::onFrame() {
+	// if the unit is not busy and doesnt have a job
+	if (!this->isBusy() && !this->hasOrder()) {
+		// get build order from strategist
 		auto order = Strategist::getInstance().getUnitOrder(this->type);
-		if (order.has_value()) // if build order recieved
-		{					   // store results
+		if (order.has_value()) 
 			this->buildOrder = order.value();
+		else {
+			// build order doesn't exist, check upgrade order
+			auto upgrade = Strategist::getInstance().getUnitUpgradeOrder(this->type);
+			if (upgrade.has_value())
+				this->upgradeOrder = upgrade.value();
 		}
 	}
 
-	//if there's an order and it is not busy
-	if (this->buildOrder != BWAPI::UnitTypes::Unknown && !this->isBusy())
-	{//build
-		unit->build(this->buildOrder);
+	if (!this->isBusy()) {
+		if (this->buildOrder != BWAPI::UnitTypes::Unknown) {
+			if (this->unit->build(this->buildOrder))
+				this->buildOrder = BWAPI::UnitTypes::Unknown;
+		}
+		else if (this->upgradeOrder != BWAPI::UpgradeTypes::Unknown) {
+			if (this->unit->upgrade(this->upgradeOrder))
+				this->upgradeOrder = BWAPI::UpgradeTypes::Unknown;
+		}
 	}
 }
 
-void BuildingWrapper::displayInfo()
-{
+void BuildingWrapper::displayInfo() {
 	BWAPI::Broodwar->drawTextMap(this->unit->getPosition(), "BuildingWrapper");
+}
+
+bool BuildingWrapper::hasOrder() {
+	return (this->buildOrder == BWAPI::UnitTypes::Unknown) && (this->upgradeOrder == BWAPI::UpgradeTypes::Unknown);
 }

--- a/src/Units/BuildingWrappers/BuildingWrapper.h
+++ b/src/Units/BuildingWrappers/BuildingWrapper.h
@@ -8,4 +8,9 @@ public:
 
     virtual void onFrame() override;
     virtual void displayInfo() override;
+    
+protected:
+    bool hasOrder();
+
+    BWAPI::UpgradeType upgradeOrder;
 };

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="..\..\libs\BWEM-community\BWEM\src\utils.cpp" />
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp" />
     <ClCompile Include="..\..\src\Players\Player.cpp" />
+    <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
@@ -188,6 +189,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\src\Players\Player.h" />
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h" />
+    <ClInclude Include="..\..\src\Players\Upgrades\Upgrades.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ProtossBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\TerranBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\UnknownBuildOrders.h" />

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\Units\NonArmyWrappers">
       <UniqueIdentifier>{d6e6c18e-6ca5-4cd4-8cfd-0e6eb408abe3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Players\Upgrades">
+      <UniqueIdentifier>{ec38fccc-15e9-413b-9e2d-d89781d9b595}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp">
@@ -132,6 +135,9 @@
     <ClCompile Include="..\..\src\Units\ArmyWrappers\ZerglingWrapper.cpp">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp">
+      <Filter>Source Files\Players\Upgrades</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">
@@ -190,6 +196,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Units\ArmyWrappers\ZerglingWrapper.h">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Players\Upgrades\Upgrades.h">
+      <Filter>Source Files\Players\Upgrades</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp" />
     <ClCompile Include="..\..\src\AdditionalPylonsClient.cpp" />
     <ClCompile Include="..\..\src\Players\Player.cpp" />
+    <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
@@ -189,6 +190,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\src\Players\Player.h" />
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h" />
+    <ClInclude Include="..\..\src\Players\Upgrades\Upgrades.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ProtossBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\TerranBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\UnknownBuildOrders.h" />

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\Units\BuildingWrappers">
       <UniqueIdentifier>{4428e8a8-261c-4d36-b1d6-284937f14695}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Players\Upgrades">
+      <UniqueIdentifier>{c956a7c2-e5b4-40fc-823a-ea6410156156}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalPylonsClient.cpp">
@@ -135,6 +138,9 @@
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp">
+      <Filter>Source Files\Players\Upgrades</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">
@@ -193,6 +199,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Units\ArmyWrappers\MutaliskWrapper.h">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Players\Upgrades\Upgrades.h">
+      <Filter>Source Files\Players\Upgrades</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
resolved #51

- added player specific upgrade tracking(unit movement, unit weapon range, unit weapon damage, etc.)
- added functionality to Strategist to handle storing and retrieving a specific `BWAPI::UnitType`'s performable upgrades
- updated BuildingWrapper to support handling upgrades
- changed the Strategist build order queues to a map of queues to reduce lines of code needed

testing:
- for testing the use of upgrades, you can add the two following lines to the `Strategist::onStart()`:
```
this->upgradeOrders[BWAPI::UnitTypes::Zerg_Spawning_Pool] = std::queue<BWAPI::UpgradeType>{};
this->upgradeOrders[BWAPI::UnitTypes::Zerg_Spawning_Pool].push(BWAPI::UpgradeTypes::Metabolic_Boost);
```
- for testing that buildings do morph into other buildings properly still, you can add the following to the end of the UnknownBuildOrders.h unknown_smallest(you will need to manually create a `BWAPI::UnitTypes::Zerg_Extractor` and assign workers to mine gas before a lair can be created):
```
{BWAPI::UnitTypes::Zerg_Lair, 16}
```