### PR TITLE
Implement strategic scouting location logic

### DIFF
--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -5,6 +5,7 @@
 
 #include "./Players/Player.h"
 #include "./Strategist/Strategist.h"
+#include "./Strategist/ScoutEngine/ScoutEngine.h"
 
 void AdditionalPylonsModule::onStart() {
 	//	initialize BWEM
@@ -26,6 +27,7 @@ void AdditionalPylonsModule::onStart() {
 	Player::getEnemyInstance().onStart(BWAPI::Broodwar->enemy()->getRace());
 
 	Strategist::getInstance().onStart();
+	ScoutEngine::getInstance().onStart();
 }
 	
 void AdditionalPylonsModule::onEnd(bool isWinner) {
@@ -33,7 +35,9 @@ void AdditionalPylonsModule::onEnd(bool isWinner) {
 }
 
 void AdditionalPylonsModule::onFrame() {
-Strategist::getInstance().onFrame();
+	Strategist::getInstance().onFrame();
+	ScoutEngine::getInstance().onFrame();
+	ScoutEngine::getInstance().displayInfo();
 
 	BWEB::Map::draw();
 

--- a/src/Lambdas/Map/MapLambdas.h
+++ b/src/Lambdas/Map/MapLambdas.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <BWAPI.h>
+#include <bwem.h>
+#include <BWEB.h>
+
+namespace lambdas::map {
+	const std::function<bool (const BWAPI::TilePosition&)> getWalkableLambda = [](const BWAPI::TilePosition& pos) -> bool {
+		BWAPI::WalkPosition walkPos = BWAPI::WalkPosition(pos);
+		for (int i = 0; i < (BWAPI::TILEPOSITION_SCALE / BWAPI::WALKPOSITION_SCALE); i++) {
+			walkPos = BWAPI::WalkPosition(walkPos.x + (i % 2), walkPos.y + (i / 2));
+			if (!BWAPI::Broodwar->isWalkable(walkPos))
+				return false;
+		}
+		return true;
+	};
+}

--- a/src/Lambdas/Unit/UnitLambdas.h
+++ b/src/Lambdas/Unit/UnitLambdas.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <BWAPI.h>
+#include <bwem.h>
+#include <BWEB.h>
+
+#include "../../Players/Player.h"
+
+namespace lambdas::unit {
+	const std::function<bool (const std::shared_ptr<UnitWrapper>)> getAllUnitsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnitType() != BWAPI::UnitTypes::Unknown;
+	};
+
+	const std::function<bool (const std::shared_ptr<UnitWrapper>)> getAllVisibleUnitsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnit()->isVisible(BWAPI::Broodwar->self());
+	};
+
+	const std::function<bool(const std::shared_ptr<UnitWrapper>)> getResourceDepotUnitsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnitType() == Player::getEnemyInstance().getRace().getResourceDepot();
+	};
+
+	const std::function<bool(const std::shared_ptr<UnitWrapper>)> getBuildingsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnitType().isBuilding();
+	};
+
+	const std::function<bool(const std::shared_ptr<UnitWrapper>)> getArmyUnitsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnitType().canAttack();
+	};
+
+	const std::function<bool(const std::shared_ptr<UnitWrapper>)> getVisibleArmyUnitsLambda = [](const std::shared_ptr<UnitWrapper> unit) -> bool {
+		return unit.get()->getUnitType().canAttack() && unit.get()->getUnit()->isVisible(BWAPI::Broodwar->self());
+	};
+}

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -1,53 +1,68 @@
 #include "./Player.h"
 
-//Auto assigns this player's race and sets enemies race to unknown
+#include <limits>
+
+#include "../Strategist/Strategist.h"
+
 void Player::onStart(BWAPI::Race race) {
-	this->armyUnits.clear();
-	this->nonArmyUnits.clear();
-	this->buildingUnits.clear();
-	this->allUnits.clear();
-	this->playerRace = race;
+    this->armyUnits.clear();
+    this->nonArmyUnits.clear();
+    this->buildingUnits.clear();
+    this->allUnits.clear();
+    this->playerRace = race;
 }
 
 void Player::onFrame() {
-	for (auto& [key, value] : this->armyUnits) {
-		value->onFrame();
-		value->displayInfo();
-	}
-		
-	for (auto& [key, value] : this->nonArmyUnits) {
-		value->onFrame();
-		value->displayInfo();
-	}
-		
-	for (auto& [key, value] : this->buildingUnits) {
-		value->onFrame();
-		value->displayInfo();
-	}
+    for (auto& [key, value] : this->armyUnits) {
+        value->onFrame();
+        value->displayInfo();
+    }
+
+    for (auto& [key, value] : this->nonArmyUnits) {
+        value->onFrame();
+        value->displayInfo();
+    }
+
+    for (auto& [key, value] : this->buildingUnits) {
+        value->onFrame();
+        value->displayInfo();
+    }
 }
 
 void Player::onNukeDetect(BWAPI::Position target) {
-
 }
 
 void Player::onUnitEvade(BWAPI::Unit unit) {
-
 }
 
 void Player::onUnitHide(BWAPI::Unit unit) {
-
 }
 
-//When a unit is created, adds unit to maps corresponding to type
+// When a unit is created, adds unit to maps corresponding to type
 void Player::onUnitCreate(BWAPI::Unit unit) {
 	//If this is the first time seeing an enemy unit, we now know what race the enemy is
-	if (this->playerRace == BWAPI::Races::Unknown)
+	if (this->playerRace == BWAPI::Races::Unknown) {
 		this->playerRace = unit->getType().getRace();
+		Strategist::getInstance().swapBuildOrder();
+	}
 
-	if (unit->getType().isBuilding())
-		this->buildingUnits[unit->getID()] = std::make_unique<BuildingWrapper>(BuildingWrapper(unit));
-	else if (unit->getType().isWorker())
+	if (unit->getType().isBuilding()) {
+        auto area = BWEM::Map::Instance().GetArea(unit->getTilePosition());
+        if (area) {
+            if (buildingAreas.insert(area).second) {
+                for (auto& mineral : area->Minerals()) {
+                    allMinerals[mineral] = 0;
+                }
+                for (auto& geyser : area->Geysers()) {
+                    allGeysers[geyser] = 0;
+                }
+            }
+        }
+        this->buildingUnits[unit->getID()] = std::make_unique<BuildingWrapper>(BuildingWrapper(unit));
+    }
+	else if (unit->getType().isWorker()) {
 		this->nonArmyUnits[unit->getID()] = std::make_unique<WorkerWrapper>(WorkerWrapper(unit));
+	}
 	else {
 		switch (unit->getType()) {
 		case BWAPI::UnitTypes::Zerg_Larva: this->nonArmyUnits[unit->getID()] = std::make_unique<LarvaWrapper>(LarvaWrapper(unit)); break;
@@ -62,84 +77,101 @@ void Player::onUnitCreate(BWAPI::Unit unit) {
 	this->allUnits[unit->getID()] = std::make_unique<UnitWrapper>(UnitWrapper(unit));
 }
 
-//When a unit is destroyed, removes unit from maps corresponding type
+// When a unit is destroyed, removes unit from maps corresponding type
 void Player::onUnitDestroy(BWAPI::Unit unit) {
-	if (unit->getType().isBuilding())
-		this->buildingUnits.erase(unit->getID());
-	else if (unit->getType().isWorker() || unit->getType() == BWAPI::UnitTypes::Zerg_Larva || unit->getType() == BWAPI::UnitTypes::Zerg_Overlord)
+
+    if (unit->getType().isBuilding()) {
+        this->buildingUnits.erase(unit->getID());
+    } else if (unit->getType().isWorker()) {
+		auto unitIter = this->nonArmyUnits.find(unit->getID());
+		if(unitIter != nonArmyUnits.end()){
+			auto worker = static_cast<WorkerWrapper*>(unitIter->second.get());
+			auto res = worker->getCurrentResource();
+			if(res){
+				this->adjustResourceWorkerCount(res, -1);
+			}
+		}
 		this->nonArmyUnits.erase(unit->getID());
-	else
-		this->armyUnits.erase(unit->getID());
-	this->allUnits.erase(unit->getID());
+
+    } else if (unit->getType() == BWAPI::UnitTypes::Zerg_Larva || unit->getType() == BWAPI::UnitTypes::Zerg_Overlord) {
+        this->nonArmyUnits.erase(unit->getID());
+    } else {
+        this->armyUnits.erase(unit->getID());
+    }
+    this->allUnits.erase(unit->getID());
 }
 
 void Player::onUnitMorph(BWAPI::Unit unit) {
-	this->buildingUnits.erase(unit->getID());
-	this->nonArmyUnits.erase(unit->getID());
-	this->armyUnits.erase(unit->getID());
-	this->allUnits.erase(unit->getID());
-	onUnitCreate(unit);
+    this->buildingUnits.erase(unit->getID());
+    this->nonArmyUnits.erase(unit->getID());
+    this->armyUnits.erase(unit->getID());
+    this->allUnits.erase(unit->getID());
+    onUnitCreate(unit);
 }
 
 void Player::onUnitRenegade(BWAPI::Unit unit) {
-
 }
 
 void Player::onUnitComplete(BWAPI::Unit unit) {
-
 }
 
 void Player::onUnitDiscover(BWAPI::Unit unit) {
-
 }
 
 std::unordered_map<int, BWAPI::Unit> Player::getUnitsByType(BWAPI::UnitType type) {
-	std::unordered_map<int, BWAPI::Unit> specUnits;
-	if (type == BWAPI::UnitTypes::Unknown) {
-		for (auto& [key, value] : this->allUnits) {
-			specUnits[value->getID()] = value->getUnit();
-		}
-	}
-	else {
-		for (auto& [key, value] : this->allUnits) {
-			if (value->getUnitType() == type)
-				specUnits[value->getID()] = value->getUnit();
-		}
-	}
+    std::unordered_map<int, BWAPI::Unit> specUnits;
+    if (type == BWAPI::UnitTypes::Unknown) {
+        for (auto& [key, value] : this->allUnits) {
+            specUnits[value->getID()] = value->getUnit();
+        }
+    } else {
+        for (auto& [key, value] : this->allUnits) {
+            if (value->getUnitType() == type)
+                specUnits[value->getID()] = value->getUnit();
+        }
+    }
 
-	return specUnits;
+    return specUnits;
 }
 
-//Displays player info (race, # of units, # of buildings)
+// Displays player info (race, # of units, # of buildings)
 void Player::displayInfo(int x) {
-	std::string race;
+    std::string race;
 
-	switch (this->playerRace) {
-	case BWAPI::Races::Enum::Protoss: race = "Protoss"; break;
-	case BWAPI::Races::Enum::Terran: race = "Terran"; break;
-	case BWAPI::Races::Enum::Zerg: race = "Zerg"; break;
-	default: race = "Unknown"; break;
-	}
+    switch (this->playerRace) {
+        case BWAPI::Races::Enum::Protoss:
+            race = "Protoss";
+            break;
+        case BWAPI::Races::Enum::Terran:
+            race = "Terran";
+            break;
+        case BWAPI::Races::Enum::Zerg:
+            race = "Zerg";
+            break;
+        default:
+            race = "Unknown";
+            break;
+    }
 
-	BWAPI::Broodwar->setTextSize(BWAPI::Text::Size::Large);
-	BWAPI::Broodwar->drawTextScreen(x, 50, "Race: %s", race.c_str());
-	BWAPI::Broodwar->drawTextScreen(x, 65, "Units: %d", this->armyUnits.size() + this->nonArmyUnits.size());
-	BWAPI::Broodwar->drawTextScreen(x, 80, "Buildings: %d", this->buildingUnits.size());
-	BWAPI::Broodwar->setTextSize(BWAPI::Text::Size::Default);
+    BWAPI::Broodwar->setTextSize(BWAPI::Text::Size::Large);
+    BWAPI::Broodwar->drawTextScreen(x, 50, "Race: %s", race.c_str());
+    BWAPI::Broodwar->drawTextScreen(x, 65, "Units: %d", this->armyUnits.size() + this->nonArmyUnits.size());
+    BWAPI::Broodwar->drawTextScreen(x, 80, "Buildings: %d", this->buildingUnits.size());
+    BWAPI::Broodwar->setTextSize(BWAPI::Text::Size::Default);
 }
 
 std::unordered_map<int, BWAPI::Unit> Player::getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight) {
-	std::unordered_map<int, BWAPI::Unit> areaUnits;
-	for (auto& [key, value] : this->allUnits) {
-		BWAPI::Position unitPos = value->getUnit()->getPosition();
-		if (((topLeft == unitPos) || (topLeft < unitPos)) &&
-			((unitPos == botRight) || (unitPos < botRight)))
-			areaUnits[value->getID()] = value->getUnit();
-		else
-			continue;
-	}
+    std::unordered_map<int, BWAPI::Unit> areaUnits;
+    for (auto& [key, value] : this->allUnits) {
+        BWAPI::Position unitPos = value->getUnit()->getPosition();
+        if (((topLeft == unitPos) || (topLeft < unitPos)) &&
+            ((unitPos == botRight) || (unitPos < botRight)))
+            areaUnits[value->getID()] = value->getUnit();
+        else
+            continue;
+    }
 
-	return areaUnits;
+    return areaUnits;
 }
 
 std::map<BWAPI::UnitType, int> Player::getUnitCount() {
@@ -153,4 +185,67 @@ std::map<BWAPI::UnitType, int> Player::getUnitCount() {
 	}
 	return counts;
 }
+
+BWEM::Ressource* Player::getClosestGeyser(BWAPI::Position pos) {
+    return this->getClosestResource(pos, this->allGeysers);
+}
+
+BWEM::Ressource* Player::getClosestMineral(BWAPI::Position pos) {
+    return this->getClosestResource(pos, this->allMinerals);
+}
+
+// We iterate through both the known geysers and the known minerals.
+// sum up the amount of workers on each resource.
+// and return either their ratio of gas:minerals or FLOAT_MAX if there are no mineral workers
+float Player::getGasToMineralWorkerRatio() {
+    int totalGeyserWorkers = 0;
+    int totalMineralWorkers = 0;
+    for (auto& [key, value] : this->allGeysers) {
+        totalGeyserWorkers += value;
+    }
+    for (auto& [key, value] : this->allMinerals) {
+        totalMineralWorkers += value;
+    }
+    return totalMineralWorkers != 0 ? (float)totalGeyserWorkers / (float)totalMineralWorkers : std::numeric_limits<float>::max();
+}
+
+// We determine if a given resource is a mineralfield or a geyser.
+// If we can find the resource in our resource maps, adjust the worker count for that resource
+void Player::adjustResourceWorkerCount(BWEM::Ressource* res, int val) {
+    if (res->Unit()->getType().isMineralField()) {
+        auto mineralIter = allMinerals.find(res);
+        if(mineralIter != allMinerals.end()) {
+            mineralIter->second += val;
+        }
+    } else {
+        auto geyserIter = allGeysers.find(res);
+        if(geyserIter != allGeysers.end()) {
+            geyserIter->second += val;
+        }
+	}
+}
+
+BWEM::Ressource* Player::getClosestResource(BWAPI::Position pos, const std::map<BWEM::Ressource*, int>& resources) {
+    BWEM::Ressource* closest = nullptr;
+    size_t closestDistance = SIZE_MAX;
+
+    for (auto& [key, value] : resources) {
+        if (value >= 3)
+            continue;
+        auto path = BWEB::Path(pos, key->Pos(), BWAPI::UnitTypes::Zerg_Drone);
+        path.generateJPS([&](const BWAPI::TilePosition& pos) {
+            BWAPI::WalkPosition walkPos = BWAPI::WalkPosition(pos);
+            for (int i = 0; i < (BWAPI::TILEPOSITION_SCALE / BWAPI::WALKPOSITION_SCALE); i++) {
+                walkPos = BWAPI::WalkPosition(walkPos.x + (i % 2), walkPos.y + (i / 2));
+                if (!BWAPI::Broodwar->isWalkable(walkPos))
+                    return false;
+            }
+             return true;
+        });
+        if(path.isReachable() && path.getTiles().size() < closestDistance){
+            closest = key;
+            closestDistance = path.getTiles().size();
+        }
+    }
+    return closest;
 }

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -141,3 +141,16 @@ std::unordered_map<int, BWAPI::Unit> Player::getUnitsByArea(BWAPI::Position topL
 
 	return areaUnits;
 }
+
+std::map<BWAPI::UnitType, int> Player::getUnitCount() {
+	std::map<BWAPI::UnitType, int> counts;
+	for (const auto& [key, value] : this->allUnits) {
+		auto countIter = counts.find(value->getUnitType());
+		if (countIter != counts.end())
+			countIter->second++;
+		else
+			counts[value->getUnitType()] = 1;
+	}
+	return counts;
+}
+}

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -1,5 +1,4 @@
 #include "./Player.h"
-#include "../Strategist/Strategist.h"
 
 #include <limits>
 

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -63,4 +63,11 @@ public:
         @retval std::unordered_map<int, BWAPI::Unit> map of units by unit type
     */
     std::unordered_map<int, BWAPI::Unit> getUnitsByType(BWAPI::UnitType type);
+
+    /*
+    Returns a map of count of each BWAPI::UnitType owned by the player
+    @returns
+        @retval std::map<BWAPI::UnitType, int> map of count of each BWAPI::UnitType
+    */
+    std::map<BWAPI::UnitType, int> getUnitCount();
 };

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -58,12 +58,12 @@ public:
     std::unordered_map<int, BWAPI::Unit> getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight);
 
     /*
-    Returns a map of all units of a specified type
-    Returns all units if type is BWAPI::UnitTypes::Unknown
+    Returns a map of all units matching some predicate function
+    The Predicate function should return true for units it return, and false for those to be excluded
     @returns
-        @retval std::unordered_map<int, BWAPI::Unit> map of units by unit type
+        @retval std::unordered_map<int, BWAPI::Unit> map of units
     */
-    std::unordered_map<int, BWAPI::Unit> getUnitsByType(BWAPI::UnitType type);
+    std::unordered_map<int, BWAPI::Unit> getUnitsByPredicate(std::function <bool(const BWAPI::Unit&)> predicate);
 
     /*
     Returns a map of count of each BWAPI::UnitType owned by the player
@@ -107,6 +107,17 @@ public:
     res as the resource, val as the amount to adjust it by.
     */
     void adjustResourceWorkerCount(BWEM::Ressource* res, int val);
+
+    /*
+    Returns the number of army units the player instance has
+    @returns
+        @retval int of the number of army units associated with the player
+    */
+    int getArmyUnitCount() { return this->armyUnits.size(); }
+
+    const BWAPI::Unit getClosestUnitTo(BWAPI::Position pos, BWAPI::UnitType type);
+
+    const BWEM::Area* getClosestAreaTo(BWAPI::Position pos, BWAPI::UnitType type);
 
 private:
     Player() = default;

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -63,7 +63,7 @@ public:
     @returns
         @retval std::unordered_map<int, BWAPI::Unit> map of units
     */
-    std::unordered_map<int, BWAPI::Unit> getUnitsByPredicate(std::function <bool(const BWAPI::Unit&)> predicate);
+    std::unordered_map<int, BWAPI::Unit> getUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> predicate);
 
     /*
     Returns a map of count of each BWAPI::UnitType owned by the player
@@ -115,10 +115,6 @@ public:
     */
     int getArmyUnitCount() { return this->armyUnits.size(); }
 
-    const BWAPI::Unit getClosestUnitTo(BWAPI::Position pos, BWAPI::UnitType type);
-
-    const BWEM::Area* getClosestAreaTo(BWAPI::Position pos, BWAPI::UnitType type);
-
 private:
     Player() = default;
 
@@ -130,10 +126,10 @@ private:
     */
     BWEM::Ressource* getClosestResource(BWAPI::Position pos, const std::map<BWEM::Ressource*, int>& resources);
 
-    std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
-    std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
-    std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
-    std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
+    std::unordered_map<int, std::shared_ptr<ArmyWrapper>> armyUnits;
+    std::unordered_map<int, std::shared_ptr<NonArmyWrapper>> nonArmyUnits;
+    std::unordered_map<int, std::shared_ptr<BuildingWrapper>> buildingUnits;
+    std::unordered_map<int, std::shared_ptr<UnitWrapper>> allUnits;
     std::map<BWEM::Ressource*, int> allGeysers;
     std::map<BWEM::Ressource*, int> allMinerals;
     std::set<const BWEM::Area*> buildingAreas;

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -1,24 +1,21 @@
 #pragma once
-#include <unordered_map>
-#include <string>
+#include <map>
 #include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
 
 #include <BWAPI.h>
+#include <BWEB.h>
+#include <bwem.h>
 
 #include "../Units/Units.h"
 
 class Player {
-private:
-    std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
-    std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
-    std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
-    std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
-    BWAPI::Race playerRace;
-    Player() = default;
-
 public:
     Player(const Player&) = delete;
     Player(const Player&&) = delete;
+
     /*
     Returns the current instance of the player's instance
     @returns
@@ -28,6 +25,7 @@ public:
         static Player instance;
         return instance;
     }
+
     /*
     Returns the current instance of the enemy's instance
     @returns
@@ -37,6 +35,7 @@ public:
         static Player instance;
         return instance;
     }
+
     void onStart(BWAPI::Race race);
     void onFrame();
     void onNukeDetect(BWAPI::Position target);
@@ -50,12 +49,14 @@ public:
     void onUnitDiscover(BWAPI::Unit unit);
     BWAPI::Race getRace() { return this->playerRace; }
     void displayInfo(int x);
+
     /*
     Returns a map of all units in a specified area
     @returns
         @retval std::unordered_map<int, BWAPI::Unit> map of units in given area
     */
     std::unordered_map<int, BWAPI::Unit> getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight);
+
     /*
     Returns a map of all units of a specified type
     Returns all units if type is BWAPI::UnitTypes::Unknown
@@ -70,4 +71,60 @@ public:
         @retval std::map<BWAPI::UnitType, int> map of count of each BWAPI::UnitType
     */
     std::map<BWAPI::UnitType, int> getUnitCount();
+
+    /*
+    Returns a set of all BWEM::Area*'s associated with the player
+    @returns
+        @retval std::set<const BWEM::Area*> set of all player owned BWEM::Area*
+    */
+    const std::set<const BWEM::Area*>& getBuildingAreas() { return buildingAreas; };
+
+    /*
+    Returns the closest geyser or nullptr if no geyser found
+    @returns
+        @retval BWEM::Ressource* to the closest resource
+        @retval nullptr if no geyser was found
+    */
+    BWEM::Ressource* getClosestGeyser(BWAPI::Position pos);
+
+    /*
+    Returns the closest mineral or nullptr if no mineral found
+    @returns
+        @retval BWEM::Ressource* to the closest resource
+        @retval nullptr if no mineral was found
+    */
+    BWEM::Ressource* getClosestMineral(BWAPI::Position pos);
+
+    /*
+    Returns the ratio of gas:mineral workers or FLOAT_MAX if the number of mineral workers is 0
+    @returns
+        @retval float of the ratio of gas:mineral workers
+    */
+    float getGasToMineralWorkerRatio();
+
+    /*
+    Adjusts the amount of workers for a given resource.
+    res as the resource, val as the amount to adjust it by.
+    */
+    void adjustResourceWorkerCount(BWEM::Ressource* res, int val);
+
+private:
+    Player() = default;
+
+    /*
+    Returns the closest ground distance based player associated resource to a position
+    @returns
+        @retval BWEM::Ressource* to the closest resource
+        @retval nullptr if no resource was found
+    */
+    BWEM::Ressource* getClosestResource(BWAPI::Position pos, const std::map<BWEM::Ressource*, int>& resources);
+
+    std::unordered_map<int, std::unique_ptr<ArmyWrapper>> armyUnits;
+    std::unordered_map<int, std::unique_ptr<NonArmyWrapper>> nonArmyUnits;
+    std::unordered_map<int, std::unique_ptr<BuildingWrapper>> buildingUnits;
+    std::unordered_map<int, std::unique_ptr<UnitWrapper>> allUnits;
+    std::map<BWEM::Ressource*, int> allGeysers;
+    std::map<BWEM::Ressource*, int> allMinerals;
+    std::set<const BWEM::Area*> buildingAreas;
+    BWAPI::Race playerRace;
 };

--- a/src/Strategist/ScoutEngine/ScoutEngine.cpp
+++ b/src/Strategist/ScoutEngine/ScoutEngine.cpp
@@ -1,0 +1,29 @@
+#include "./ScoutEngine.h"
+
+#include <algorithm>
+
+void ScoutEngine::onStart() {
+	this->startingLocations = BWAPI::Broodwar->getStartLocations();
+}
+
+void ScoutEngine::onFrame() {
+	// not sure what needs to be done here yet, if anything
+}
+
+void ScoutEngine::setScout(BWAPI::Unit unit) {
+	this->scout = unit;
+}
+
+void ScoutEngine::onUnitDestroy(BWAPI::Unit unit) {
+	if (unit == this->scout)
+		this->scout = nullptr;
+}
+
+BWAPI::TilePosition ScoutEngine::getNextBaseToScout() {
+	//	first, sort the starting bases
+	std::sort(this->startingLocations.begin(), this->startingLocations.end(),
+		[](const BWAPI::TilePosition& a, const BWAPI::TilePosition& b) {
+			return BWAPI::Broodwar->isExplored(a) < BWAPI::Broodwar->isExplored(b);
+		});
+	return this->startingLocations.front();
+}

--- a/src/Strategist/ScoutEngine/ScoutEngine.cpp
+++ b/src/Strategist/ScoutEngine/ScoutEngine.cpp
@@ -2,15 +2,20 @@
 
 #include <algorithm>
 
+#include <bwem.h>
+
 void ScoutEngine::onStart() {
-	auto locations = BWAPI::Broodwar->getStartLocations();
-	for (const auto& location : locations) {
-		this->startLocationFrameVisitibilityMap.emplace_back(std::make_pair(location, BWAPI::Broodwar->getFrameCount()));
+	for (const auto& area : BWEM::Map::Instance().Areas()) {
+		for (const auto& base : area.Bases()) {
+			this->baseLocationFrameVisitibilityMap.emplace_back(std::make_pair(base.Center(), BWAPI::Broodwar->getFrameCount()));
+		}
 	}
+	
+	this->sortScoutBases();
 }
 
 void ScoutEngine::onFrame() {
-	for (auto& location : this->startLocationFrameVisitibilityMap) {
+	for (auto& location : this->baseLocationFrameVisitibilityMap) {
 		if (BWAPI::Broodwar->isVisible(location.first)) {
 			location.second = BWAPI::Broodwar->getFrameCount();
 		}
@@ -19,28 +24,39 @@ void ScoutEngine::onFrame() {
 
 BWAPI::TilePosition ScoutEngine::getNextBaseToScout() {
 	// grab location first before sorting
-	auto location = this->startLocationFrameVisitibilityMap.begin()->first;
+	auto location = this->baseLocationFrameVisitibilityMap.begin()->first;
 
 	// swap first location with last before sorting, to ensure selected location is not first next
-	std::swap(this->startLocationFrameVisitibilityMap.front(), this->startLocationFrameVisitibilityMap.back());
+	std::swap(this->baseLocationFrameVisitibilityMap.front(), this->baseLocationFrameVisitibilityMap.back());
 	
-	//	first, sort the starting bases
-	std::sort(this->startLocationFrameVisitibilityMap.begin(), this->startLocationFrameVisitibilityMap.end(),
-		[](const std::pair<BWAPI::TilePosition, int>& a, const std::pair<BWAPI::TilePosition, int>& b) {
-			auto exploredA = BWAPI::Broodwar->isExplored(a.first);
-			auto exploredB = BWAPI::Broodwar->isExplored(b.first);
-			if (exploredA == exploredB) {
-				return a.second < b.second;
-			} else {
-				return exploredA < exploredB;
-			}
-		});
+	// re-sort bases
+	this->sortScoutBases();
 
 	return location;
 }
 
 void ScoutEngine::displayInfo() {
-	for (const auto& location : this->startLocationFrameVisitibilityMap) {
+	for (const auto& location : this->baseLocationFrameVisitibilityMap) {
 		BWAPI::Broodwar->drawTextMap(BWAPI::Position(location.first), "frame: %d", location.second);
 	}
+}
+
+void ScoutEngine::sortScoutBases() {
+	std::sort(this->baseLocationFrameVisitibilityMap.begin(), this->baseLocationFrameVisitibilityMap.end(),
+		[](const std::pair<BWAPI::TilePosition, int>& a, const std::pair<BWAPI::TilePosition, int>& b) {
+			auto exploredA = BWAPI::Broodwar->isExplored(a.first);
+			auto exploredB = BWAPI::Broodwar->isExplored(b.first);
+			auto startingLocations = BWAPI::Broodwar->getStartLocations();
+			auto isAStarting = std::find(startingLocations.begin(), startingLocations.end(), a.first) != startingLocations.end();
+			auto isBStarting = std::find(startingLocations.begin(), startingLocations.end(), b.first) != startingLocations.end();
+			if (isAStarting == isBStarting) {
+				if (exploredA == exploredB) {
+					return a.second < b.second;
+				} else {
+					return exploredA < exploredB;
+				}
+			} else {
+				return isAStarting > isBStarting;
+			}
+		});
 }

--- a/src/Strategist/ScoutEngine/ScoutEngine.h
+++ b/src/Strategist/ScoutEngine/ScoutEngine.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <deque>
+
+#include <BWAPI.h>
+
+class ScoutEngine {
+public:
+	ScoutEngine() = default;
+
+	void onStart();
+	void onFrame();
+	void setScout(BWAPI::Unit unit);
+	void onUnitDestroy(BWAPI::Unit unit);
+
+	/*
+	Returns the next base location to scout to find the enemy
+	Returns BWAPI::TilePositions::Invalid if there is no base to scout
+	@returns
+		@retval BWAPI::TilePosition of the base to start scouting towards
+	*/
+	BWAPI::TilePosition getNextBaseToScout();
+
+	/*
+	Returns if we currently have a unit assigned to scout
+	@returns
+		@retval bool check on if a BWAPI::Unit is assigned to scout
+	*/
+	bool haveScout() { return this->scout != nullptr; }
+private:
+	std::deque<BWAPI::TilePosition> startingLocations;
+	BWAPI::Unit scout = nullptr;
+};

--- a/src/Strategist/ScoutEngine/ScoutEngine.h
+++ b/src/Strategist/ScoutEngine/ScoutEngine.h
@@ -28,9 +28,11 @@ public:
 
 	void displayInfo();
 
-private:
+protected:
 	ScoutEngine() = default;
 
-	std::vector<std::pair<BWAPI::TilePosition, int>> startLocationFrameVisitibilityMap;
+	void sortScoutBases();
+
+	std::vector<std::pair<BWAPI::TilePosition, int>> baseLocationFrameVisitibilityMap;
 	BWAPI::Unit scout = nullptr;
 };

--- a/src/Strategist/ScoutEngine/ScoutEngine.h
+++ b/src/Strategist/ScoutEngine/ScoutEngine.h
@@ -1,16 +1,22 @@
 #pragma once
-#include <deque>
+#include <set>
 
 #include <BWAPI.h>
 
 class ScoutEngine {
 public:
-	ScoutEngine() = default;
+	ScoutEngine(const ScoutEngine&) = delete;
+    ScoutEngine(const ScoutEngine&&) = delete;
+    ScoutEngine operator=(const ScoutEngine&) = delete;
+    ScoutEngine& operator=(const ScoutEngine&&) = delete;
+
+	static ScoutEngine& getInstance() {
+        static ScoutEngine instance;
+        return instance;
+    }
 
 	void onStart();
 	void onFrame();
-	void setScout(BWAPI::Unit unit);
-	void onUnitDestroy(BWAPI::Unit unit);
 
 	/*
 	Returns the next base location to scout to find the enemy
@@ -20,13 +26,11 @@ public:
 	*/
 	BWAPI::TilePosition getNextBaseToScout();
 
-	/*
-	Returns if we currently have a unit assigned to scout
-	@returns
-		@retval bool check on if a BWAPI::Unit is assigned to scout
-	*/
-	bool haveScout() { return this->scout != nullptr; }
+	void displayInfo();
+
 private:
-	std::deque<BWAPI::TilePosition> startingLocations;
+	ScoutEngine() = default;
+
+	std::vector<std::pair<BWAPI::TilePosition, int>> startLocationFrameVisitibilityMap;
 	BWAPI::Unit scout = nullptr;
 };

--- a/src/Strategist/Strategist.cpp
+++ b/src/Strategist/Strategist.cpp
@@ -18,7 +18,7 @@ void Strategist::onFrame() {
         updateUnitQueue();
     }
 
-    if (!this->checkIfEnemyBaseFound()) {
+    if (!this->checkIfEnemyBaseFound() && Player::getEnemyInstance().getArmyUnitCount() <= 0) {
         this->playDecision = PlayDecision::scout;
     } else {
         this->playDecision = PlayDecision::attack;
@@ -165,7 +165,9 @@ void Strategist::updateUnitQueue() {
 }
 
 bool Strategist::checkIfEnemyBaseFound() {
-    std::unordered_map<int, BWAPI::Unit> depot = Player::getEnemyInstance().getUnitsByType(Player::getEnemyInstance().getRace().getResourceDepot());
+    auto depot = Player::getEnemyInstance().getUnitsByPredicate([](const BWAPI::Unit& unit) {
+        return unit->getType() == Player::getEnemyInstance().getRace().getResourceDepot();
+    });
     return(!depot.empty());
 }
 

--- a/src/Strategist/Strategist.cpp
+++ b/src/Strategist/Strategist.cpp
@@ -10,7 +10,6 @@ void Strategist::onStart() {
     supply_total = BWAPI::Broodwar->self()->supplyTotal();
     chooseOpeningBuildOrder();
     playDecision = PlayDecision::scout;
-    this->scoutEngine.onStart();
 }
 
 void Strategist::onFrame() {
@@ -19,8 +18,10 @@ void Strategist::onFrame() {
         updateUnitQueue();
     }
 
-    if (playDecision == PlayDecision::scout && foundEnemyBase()) {
-        playDecision = PlayDecision::none;
+    if (!this->checkIfEnemyBaseFound()) {
+        this->playDecision = PlayDecision::scout;
+    } else {
+        this->playDecision = PlayDecision::attack;
     }
 }
 
@@ -163,7 +164,7 @@ void Strategist::updateUnitQueue() {
     }
 }
 
-bool Strategist::foundEnemyBase() {
+bool Strategist::checkIfEnemyBaseFound() {
     std::unordered_map<int, BWAPI::Unit> depot = Player::getEnemyInstance().getUnitsByType(Player::getEnemyInstance().getRace().getResourceDepot());
     return(!depot.empty());
 }

--- a/src/Strategist/Strategist.cpp
+++ b/src/Strategist/Strategist.cpp
@@ -1,9 +1,12 @@
 #include "Strategist.h"
-#include "../Players/Player.h"
+
 #include "./BuildOrders/UnknownBuildOrders.h"
 #include "./BuildOrders/ZergBuildOrders.h"
 #include "./BuildOrders/TerranBuildOrders.h"
 #include "./BuildOrders/ProtossBuildOrders.h"
+
+#include "../Players/Player.h"
+#include "../Lambdas/Unit/UnitLambdas.h"
 
 void Strategist::onStart() {
     // Get initial gamestate information
@@ -18,7 +21,7 @@ void Strategist::onFrame() {
         updateUnitQueue();
     }
 
-    if (!this->checkIfEnemyBaseFound() && Player::getEnemyInstance().getArmyUnitCount() <= 0) {
+    if (!this->checkIfEnemyFound()) {
         this->playDecision = PlayDecision::scout;
     } else {
         this->playDecision = PlayDecision::attack;
@@ -164,11 +167,9 @@ void Strategist::updateUnitQueue() {
     }
 }
 
-bool Strategist::checkIfEnemyBaseFound() {
-    auto depot = Player::getEnemyInstance().getUnitsByPredicate([](const BWAPI::Unit& unit) {
-        return unit->getType() == Player::getEnemyInstance().getRace().getResourceDepot();
-    });
-    return(!depot.empty());
+bool Strategist::checkIfEnemyFound() {
+    return(!(Player::getEnemyInstance().getUnitsByPredicate(lambdas::unit::getBuildingsLambda).empty() &&
+        Player::getEnemyInstance().getUnitsByPredicate(lambdas::unit::getVisibleArmyUnitsLambda).empty()));
 }
 
 void Strategist::displayInfo(int x) {

--- a/src/Strategist/Strategist.h
+++ b/src/Strategist/Strategist.h
@@ -46,7 +46,7 @@ private:
     void updateUnitQueue();
 
     void onStartAttemptFindEnemyStartingBase();
-    bool checkIfEnemyBaseFound();
+    bool checkIfEnemyFound();
 
     int minerals_spent = 0;
     int gas_spent = 0;

--- a/src/Strategist/Strategist.h
+++ b/src/Strategist/Strategist.h
@@ -3,8 +3,6 @@
 #include <queue>
 #include <optional>
 
-#include "./ScoutEngine/ScoutEngine.h"
-
 enum class MapSize { smallest, medium, large };
 enum class PlayDecision { none, scout, attack, defend };
 class Strategist {
@@ -38,12 +36,7 @@ public:
     */
     void swapBuildOrder();
 
-    PlayDecision getPlayDecision();
-
-    void setScout(BWAPI::Unit unit);
-    void onPossibleScoutDestroy(BWAPI::Unit unit);
-
-    PlayDecision getPlayDecision();
+    PlayDecision getPlayDecision() { return this->playDecision; }
 
 private:
     Strategist() = default;
@@ -52,14 +45,8 @@ private:
     void chooseOpeningBuildOrder();
     void updateUnitQueue();
 
-    /*
-    Returns if we have found an enemy resource depot
-    @returns
-        @retval bool true if map is not empty
-    */
-    bool foundEnemyBase();
-
-    ScoutEngine scoutEngine = ScoutEngine();
+    void onStartAttemptFindEnemyStartingBase();
+    bool checkIfEnemyBaseFound();
 
     int minerals_spent = 0;
     int gas_spent = 0;

--- a/src/Strategist/Strategist.h
+++ b/src/Strategist/Strategist.h
@@ -3,6 +3,8 @@
 #include <queue>
 #include <optional>
 
+#include "./ScoutEngine/ScoutEngine.h"
+
 enum class MapSize { smallest, medium, large };
 enum class PlayDecision { none, scout, attack, defend };
 class Strategist {
@@ -28,19 +30,36 @@ public:
     */
     std::optional<BWAPI::UnitType> getUnitOrder(BWAPI::UnitType type);
     
-        
+    /*
+    Update our build order queue to better fit the enemies race once scouted.
+    Should only be called if our enemies race is initially Unknown.
+    @returns
+        none
+    */
+    void swapBuildOrder();
+
+    PlayDecision getPlayDecision();
+
+    void setScout(BWAPI::Unit unit);
+    void onPossibleScoutDestroy(BWAPI::Unit unit);
+
+    PlayDecision getPlayDecision();
+
 private:
     Strategist() = default;
 
     void determineMapSize();
     void chooseOpeningBuildOrder();
     void updateUnitQueue();
+
     /*
     Returns if we have found an enemy resource depot
     @returns
         @retval bool true if map is not empty
     */
     bool foundEnemyBase();
+
+    ScoutEngine scoutEngine = ScoutEngine();
 
     int minerals_spent = 0;
     int gas_spent = 0;

--- a/src/Units/ArmyWrappers/ArmyWrapper.h
+++ b/src/Units/ArmyWrappers/ArmyWrapper.h
@@ -5,4 +5,6 @@ class ArmyWrapper : public UnitWrapper {
 public:
 	ArmyWrapper(BWAPI::Unit u) : UnitWrapper(u) {};
 	~ArmyWrapper() = default;
+protected:
+	BWAPI::TilePosition scoutLocation = BWAPI::TilePositions::Invalid;
 };

--- a/src/Units/ArmyWrappers/ZerglingWrapper.cpp
+++ b/src/Units/ArmyWrappers/ZerglingWrapper.cpp
@@ -1,6 +1,63 @@
 #include "./ZerglingWrapper.h"
 
-void ZerglingWrapper::onFrame() {}
+#include <unordered_map>
+#include <BWEB.h>
+
+#include "../../Strategist/Strategist.h"
+#include "../../Strategist/ScoutEngine/ScoutEngine.h"
+#include "../../Players/Player.h"
+
+void ZerglingWrapper::onFrame() {
+	if (!this->unit->isCompleted()) return;
+
+	auto enemyAreas = Player::getEnemyInstance().getBuildingAreas();
+	BWEB::Path path = BWEB::Path();
+	size_t shortestPath = SIZE_MAX;
+	BWAPI::Unit closestUnit = nullptr;
+	const BWEM::Area* closestArea = nullptr;
+
+	switch(Strategist::getInstance().getPlayDecision()) {
+	case PlayDecision::scout:
+		if (this->scoutLocation == BWAPI::TilePositions::Invalid) {
+			this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+		}
+		if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getLastCommand().getTargetTilePosition() != this->scoutLocation) {
+			this->unit->move(BWAPI::Position(this->scoutLocation), true);
+		} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
+			if (this->scoutLocation.isValid()) {
+				if (enemyAreas.size() <= 0 || enemyAreas.find(BWEM::Map::Instance().GetArea(this->scoutLocation)) == enemyAreas.end()) {
+					this->scoutLocation == BWAPI::TilePositions::Invalid;
+				}
+			}
+		}
+		break;
+	case PlayDecision::attack:
+		closestUnit = Player::getEnemyInstance().getClosestUnitTo(this->unit->getPosition(), this->type);
+		if (closestUnit) {
+			if (this->unit->getLastCommand().getTarget() != closestUnit) {
+				if (closestUnit->isVisible(BWAPI::Broodwar->self())) {
+					this->unit->attack(closestUnit);
+				} else {
+					this->unit->move(closestUnit->getPosition());
+				}
+			}
+		} else {
+			closestArea = Player::getEnemyInstance().getClosestAreaTo(this->unit->getPosition(), this->type);
+			if (closestArea) {
+				BWAPI::TilePosition areaCenter = (closestArea->TopLeft() + closestArea->BottomRight()) / 2;
+				if (this->unit->getLastCommand().getTargetTilePosition() != areaCenter) {
+					this->unit->move(BWAPI::Position(areaCenter));
+				}
+			}
+		}
+		break;
+	case PlayDecision::defend:
+		break;
+	case PlayDecision::none:
+		this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation()));
+		break;
+	}
+}
 
 void ZerglingWrapper::displayInfo() {
 	BWAPI::Broodwar->drawTextMap(this->unit->getPosition(), "ZerglingWrapper");

--- a/src/Units/NonArmyWrappers/OverlordWrapper.cpp
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.cpp
@@ -1,6 +1,35 @@
 #include "./OverlordWrapper.h"
 
-void OverlordWrapper::onFrame() {}
+#include <bwem.h>
+
+#include "../../Strategist/Strategist.h"
+#include "../../Strategist/ScoutEngine/ScoutEngine.h"
+#include "../../Players/Player.h"
+
+void OverlordWrapper::onFrame() {
+	auto play = Strategist::getInstance().getPlayDecision();
+	if (play == PlayDecision::scout) {
+		if (this->scoutLocation == BWAPI::TilePositions::Invalid) {
+			this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+		}
+		if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getLastCommand().getTargetTilePosition() != this->scoutLocation) {
+			this->unit->move(BWAPI::Position(this->scoutLocation));
+		} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
+			auto area = BWEM::Map::Instance().GetArea(this->scoutLocation);
+			auto enemyAreas = Player::getEnemyInstance().getBuildingAreas();
+			// only reset the scout's location if they aren't at the enemy location
+			if (enemyAreas.find(area) == enemyAreas.end()) {
+				this->scoutLocation == BWAPI::TilePositions::Invalid;
+			}
+		}
+	} else {
+		auto area = BWEM::Map::Instance().GetArea(this->unit->getTilePosition());
+		auto enemyAreas = Player::getEnemyInstance().getBuildingAreas();
+		if (enemyAreas.find(area) == enemyAreas.end()) {
+			this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation()));
+		}
+	}
+}
 
 void OverlordWrapper::displayInfo() {
 	BWAPI::Broodwar->drawTextMap(this->unit->getPosition(), "OverlordWrapper");

--- a/src/Units/NonArmyWrappers/OverlordWrapper.cpp
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.cpp
@@ -40,9 +40,6 @@ void OverlordWrapper::onFrame() {
 }
 
 void OverlordWrapper::displayInfo() {
-	if (this->scoutLocation.isValid()) {
-		BWAPI::Broodwar->drawBoxMap(BWAPI::Position(this->scoutLocation), BWAPI::Position(this->scoutLocation + BWAPI::TilePosition(1, 1)), BWAPI::Colors::Red);
-	}
 	if (this->unit->getLastCommand().getTargetPosition().isValid()) {
 		BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTargetPosition(), BWAPI::Colors::White);
 	}

--- a/src/Units/NonArmyWrappers/OverlordWrapper.h
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.h
@@ -10,7 +10,6 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
-
 private:
-    PlayDecision play = PlayDecision::none;
+    BWAPI::TilePosition scoutLocation = BWAPI::TilePositions::Invalid;
 };

--- a/src/Units/NonArmyWrappers/OverlordWrapper.h
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "./NonArmyWrapper.h"
 
+#include "../../Strategist/Strategist.h"
+
 class OverlordWrapper : public NonArmyWrapper {
 public:
     OverlordWrapper(BWAPI::Unit u) : NonArmyWrapper(u) {};
@@ -8,4 +10,7 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
+
+private:
+    PlayDecision play = PlayDecision::none;
 };

--- a/src/Units/NonArmyWrappers/WorkerWrapper.cpp
+++ b/src/Units/NonArmyWrappers/WorkerWrapper.cpp
@@ -1,76 +1,95 @@
 #include "./WorkerWrapper.h"
-#include "../../Strategist/Strategist.h"
 #include <algorithm>
+#include "../../Players/Player.h"
+#include "../../Strategist/Strategist.h"
 #include "BWEB.h"
 
-void WorkerWrapper::onFrame()
-{
+void WorkerWrapper::onFrame() {
     // if not busy or working
-    if (this->currJob == Jobs::None || !this->isBusy())
-    { // get command from strategist
+    if (this->currJob == Jobs::None || !this->isBusy()) {  // get command from strategist
         auto order = Strategist::getInstance().getUnitOrder(this->type);
 
-        if (order.has_value()) // if build order recieved
-        {                      // store results
+        if (order.has_value())  // if build order recieved
+        {                       // store results
             this->buildOrder = order.value();
             this->currJob = Jobs::MorphIntoNewBuildings;
+            if(!this->currRes) {
+                Player::getPlayerInstance().adjustResourceWorkerCount(currRes, -1);
+                currRes = nullptr;
+            }
         }
     }
 
     // not busy + build order
-    if (this->buildOrder != BWAPI::UnitTypes::Unknown && !this->isBusy())
-    { // get closest bweb block to the starting location of the right size
-        auto tile = getBlockOfSize(this->buildOrder, BWAPI::Broodwar->self()->getStartLocation());
-        if (tile != BWAPI::TilePositions::Invalid)
-        {
-            if (!this->unit->build(this->buildOrder, tile))
-            { // build failed, move to center of build location
+    if (this->buildOrder != BWAPI::UnitTypes::Unknown && !this->isBusy()) {  // get closest BWEB block to the starting location of the right size
+        BWAPI::TilePosition tile = BWAPI::TilePositions::Invalid;
+        if (this->buildOrder == BWAPI::UnitTypes::Zerg_Extractor) {
+            for (const auto& key : Player::getPlayerInstance().getBuildingAreas()) {
+                for (const auto& geyser : key->Geysers()) {
+                    if(BWAPI::Broodwar->canBuildHere(geyser->TopLeft(), this->buildOrder)){
+                        tile = geyser->TopLeft();
+                        break;
+                    }
+                }
+                if(tile != BWAPI::TilePositions::Invalid) {
+                    break;
+                }
+            }
+        } else {
+            tile = getBlockOfSize(this->buildOrder, BWAPI::Broodwar->self()->getStartLocation());
+        }
+
+        if (tile != BWAPI::TilePositions::Invalid) {
+            if (!this->unit->build(this->buildOrder, tile)) {  // build failed, move to center of build location
                 BWAPI::TilePosition offset(this->buildOrder.tileWidth() / 2, this->buildOrder.tileHeight() / 2);
                 this->unit->move(BWAPI::Position(tile + offset));
             }
         }
-    }
-    else if (this->currJob == Jobs::None)
-    { // if slacking, go dig
-        BWAPI::Unit closest = nullptr;
+    } else if (this->currJob == Jobs::None) {
+        BWEM::Ressource* firstResOption = nullptr;
+        BWEM::Ressource* secondResOption = nullptr;
 
-        for (const auto &i : BWAPI::Broodwar->getMinerals())
-        { // find closest mineral
-            if ((closest != nullptr && this->unit->getDistance(i) < this->unit->getDistance(closest)) || closest == nullptr)
-            {
-                closest = i;
-            }
+        // check the ratio of gas to mineral workers we have, if there are too few, try to find a geyser to extract from
+        // use some arbitrary value for what the expected ratio should be, this is definitely too high
+        if(Player::getPlayerInstance().getGasToMineralWorkerRatio() < 0.25f) {
+            firstResOption = Player::getPlayerInstance().getClosestGeyser(this->unit->getPosition());
+            secondResOption = Player::getPlayerInstance().getClosestMineral(this->unit->getPosition());
+        } else {
+            firstResOption = Player::getPlayerInstance().getClosestMineral(this->unit->getPosition());
+            secondResOption = Player::getPlayerInstance().getClosestGeyser(this->unit->getPosition());
         }
-        if (closest && this->unit->gather(closest))
-        { // ROCK AND STONE
-            currJob = Jobs::MineMinerals;
+
+        // attempt to assign the worker to gather from either a mineral or geyser
+        if (firstResOption && this->unit->gather(firstResOption->Unit())) {
+            this->currJob = firstResOption->Unit()->getType().isMineralField() ? Jobs::MineMinerals : Jobs::ExtractGas;
+            Player::getPlayerInstance().adjustResourceWorkerCount(firstResOption, 1);
+            this->currRes = firstResOption;
+        } else if (secondResOption && this->unit->gather(secondResOption->Unit())) {
+            this->currJob = secondResOption->Unit()->getType().isMineralField() ? Jobs::MineMinerals : Jobs::ExtractGas;
+            Player::getPlayerInstance().adjustResourceWorkerCount(secondResOption, 1);
+            this->currRes = secondResOption;
         }
     }
 }
 
-BWAPI::TilePosition WorkerWrapper::getBlockOfSize(BWAPI::UnitType type, BWAPI::TilePosition pos)
-{
+BWAPI::TilePosition WorkerWrapper::getBlockOfSize(BWAPI::UnitType type, BWAPI::TilePosition pos) {
     std::vector<BWEB::Block> blocks = BWEB::Blocks::getBlocks();
 
     std::sort(blocks.begin(), blocks.end(),
-              [pos](BWEB::Block a, BWEB::Block b)
-              {
+              [pos](BWEB::Block a, BWEB::Block b) {
                   return a.getTilePosition().getApproxDistance(pos) < b.getTilePosition().getApproxDistance(pos);
               });
 
-    for (auto &b : blocks)
-    {
+    for (auto& b : blocks) {
         auto placements = b.getPlacements(type);
-        if (placements.size() && BWAPI::Broodwar->canBuildHere(*placements.begin(), type, this->unit))
-        {
+        if (placements.size() && BWAPI::Broodwar->canBuildHere(*placements.begin(), type, this->unit)) {
             return *placements.begin();
         }
     }
     return BWAPI::TilePositions::Invalid;
 }
 
-void WorkerWrapper::displayInfo()
-{
+void WorkerWrapper::displayInfo() {
     BWAPI::Broodwar->drawTextMap(this->unit->getPosition(), "WorkerWrapper");
     if (!this->queue.empty())
         BWAPI::Broodwar->drawLineMap(BWAPI::Position(this->unit->getTilePosition()), BWAPI::Position(this->queue.back()), BWAPI::Colors::White);

--- a/src/Units/NonArmyWrappers/WorkerWrapper.h
+++ b/src/Units/NonArmyWrappers/WorkerWrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "./NonArmyWrapper.h"
+#include "bwem.h"
 
 enum class Jobs
 {
@@ -15,9 +16,11 @@ public:
     WorkerWrapper(BWAPI::Unit u) : NonArmyWrapper(u){};
     ~WorkerWrapper() = default;
 
+    BWEM::Ressource* getCurrentResource(){return currRes;}
     void onFrame() override;
     void displayInfo() override;
 protected:
     BWAPI::TilePosition getBlockOfSize(BWAPI::UnitType type, BWAPI::TilePosition pos);
     Jobs currJob = Jobs::None;
+    BWEM::Ressource* currRes = nullptr;
 };

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj
@@ -187,6 +187,8 @@
     <ClCompile Include="..\..\src\Units\NonArmyWrappers\WorkerWrapper.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\Lambdas\Map\MapLambdas.h" />
+    <ClInclude Include="..\..\src\Lambdas\Unit\UnitLambdas.h" />
     <ClInclude Include="..\..\src\Players\Player.h" />
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ProtossBuildOrders.h" />

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="..\..\libs\BWEM-community\BWEM\src\utils.cpp" />
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp" />
     <ClCompile Include="..\..\src\Players\Player.cpp" />
+    <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
@@ -192,6 +193,7 @@
     <ClInclude Include="..\..\src\Strategist\BuildOrders\TerranBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\UnknownBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ZergBuildOrders.h" />
+    <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h" />
     <ClInclude Include="..\..\src\Strategist\Strategist.h" />
     <ClInclude Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.h" />
     <ClInclude Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.h" />

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
@@ -43,6 +43,15 @@
     <Filter Include="Source Files\Strategist\ScoutEngine">
       <UniqueIdentifier>{13e8452c-af72-4143-9938-f9c922c89c55}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Lambdas">
+      <UniqueIdentifier>{6d90999c-f35b-4761-8aec-23c05f151b0a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Lambdas\Map">
+      <UniqueIdentifier>{87634707-98f8-41bd-bbfe-d1733e9c7c4a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Lambdas\Unit">
+      <UniqueIdentifier>{0a534a33-0143-4462-be67-ae726a9624ac}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp">
@@ -199,6 +208,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h">
       <Filter>Source Files\Strategist\ScoutEngine</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Lambdas\Unit\UnitLambdas.h">
+      <Filter>Source Files\Lambdas\Unit</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Lambdas\Map\MapLambdas.h">
+      <Filter>Source Files\Lambdas\Map</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\Units\NonArmyWrappers">
       <UniqueIdentifier>{d6e6c18e-6ca5-4cd4-8cfd-0e6eb408abe3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Strategist\ScoutEngine">
+      <UniqueIdentifier>{13e8452c-af72-4143-9938-f9c922c89c55}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp">
@@ -132,6 +135,9 @@
     <ClCompile Include="..\..\src\Units\ArmyWrappers\ZerglingWrapper.cpp">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp">
+      <Filter>Source Files\Strategist\ScoutEngine</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">
@@ -190,6 +196,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Units\ArmyWrappers\ZerglingWrapper.h">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h">
+      <Filter>Source Files\Strategist\ScoutEngine</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
@@ -188,6 +188,8 @@
     <ClCompile Include="..\..\src\Units\NonArmyWrappers\WorkerWrapper.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\Lambdas\Map\MapLambdas.h" />
+    <ClInclude Include="..\..\src\Lambdas\Units\UnitLambdas.h" />
     <ClInclude Include="..\..\src\Players\Player.h" />
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ProtossBuildOrders.h" />

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -176,6 +176,7 @@
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp" />
     <ClCompile Include="..\..\src\AdditionalPylonsClient.cpp" />
     <ClCompile Include="..\..\src\Players\Player.cpp" />
+    <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
@@ -193,6 +194,7 @@
     <ClInclude Include="..\..\src\Strategist\BuildOrders\TerranBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\UnknownBuildOrders.h" />
     <ClInclude Include="..\..\src\Strategist\BuildOrders\ZergBuildOrders.h" />
+    <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h" />
     <ClInclude Include="..\..\src\Strategist\Strategist.h" />
     <ClInclude Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.h" />
     <ClInclude Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.h" />

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
@@ -40,8 +40,17 @@
     <Filter Include="Source Files\Units\BuildingWrappers">
       <UniqueIdentifier>{4428e8a8-261c-4d36-b1d6-284937f14695}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Lambdas">
+      <UniqueIdentifier>{6370867e-c1e4-460b-9520-ea2a06112253}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Lambdas\Map">
+      <UniqueIdentifier>{69952fc4-1ec5-4f80-a0c9-e79a230d11b1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Lambdas\Unit">
+      <UniqueIdentifier>{8e824ed8-880c-45c6-8b02-568e574c06ee}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\Strategist\ScoutEngine">
-      <UniqueIdentifier>{17a5ee4e-827f-4738-aff3-d4584e412cf3}</UniqueIdentifier>
+      <UniqueIdentifier>{2a90743c-5a5e-461e-b5f7-7dcf93b09c86}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -139,7 +148,7 @@
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\Strategist\ScoutEngine</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -200,8 +209,14 @@
     <ClInclude Include="..\..\src\Units\ArmyWrappers\MutaliskWrapper.h">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Lambdas\Units\UnitLambdas.h">
+      <Filter>Source Files\Lambdas\Unit</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Lambdas\Map\MapLambdas.h">
+      <Filter>Source Files\Lambdas\Map</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h">
-      <Filter>Header Files</Filter>
+      <Filter>Source Files\Strategist\ScoutEngine</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\Units\BuildingWrappers">
       <UniqueIdentifier>{4428e8a8-261c-4d36-b1d6-284937f14695}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Strategist\ScoutEngine">
+      <UniqueIdentifier>{17a5ee4e-827f-4738-aff3-d4584e412cf3}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\AdditionalPylonsClient.cpp">
@@ -135,6 +138,9 @@
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">
@@ -193,6 +199,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Units\ArmyWrappers\MutaliskWrapper.h">
       <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
resolved #45 

* Implemented a scouting engine to select a basic "most likely" enemy base to check next
* Implemented Overlord and Zergling logic to handle scouting
* Implemented basic Strategist Attack play handling for Zerglings
* Reworked some functionality for Player class for better functionality for retrieving information
* Added potentially common lambda functions for both player unit retrieval and player BWEM::Area retrieval

testing:
* you should only need to rebuild and run