### PR TITLE
fix failing dll run

### DIFF
--- a/src/Dll.cpp
+++ b/src/Dll.cpp
@@ -1,0 +1,23 @@
+#include <Windows.h>
+
+#include <BWAPI.h>
+
+#include "AdditionalPylonsModule.h"
+
+extern "C" __declspec(dllexport) void gameInit(BWAPI::Game* game) { BWAPI::BroodwarPtr = game; }
+BOOL APIENTRY DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        break;
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+extern "C" __declspec(dllexport) BWAPI::AIModule* newAIModule()
+{
+    return new AdditionalPylonsModule();
+}

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="..\..\libs\BWEM-community\BWEM\src\tiles.cpp" />
     <ClCompile Include="..\..\libs\BWEM-community\BWEM\src\utils.cpp" />
     <ClCompile Include="..\..\src\AdditionalPylonsModule.cpp" />
+    <ClCompile Include="..\..\src\Dll.cpp" />
     <ClCompile Include="..\..\src\Players\Player.cpp" />
     <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp" />
     <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp" />

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp">
       <Filter>Source Files\Players\Upgrades</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Dll.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">


### PR DESCRIPTION
* Fixed an issue where the required function exports were missing for the .dll build of the project, causing the dll to fail to load

testing:
* add `bwapi-data/AI/AdditionalPylons.dll` to the `ai` entry in the `bwapi.ini` file inside `%starcraft%/bwapi-data`
* run through chaoslauncher without launching the client