### PR TITLE
Fix player not removing bwem area

### DIFF
--- a/src/AdditionalPylonsModule.cpp
+++ b/src/AdditionalPylonsModule.cpp
@@ -45,8 +45,12 @@ void AdditionalPylonsModule::onFrame() {
 
 	BWEB::Map::draw();
 
+	Player::getPlayerInstance().updateUnitPositions();
+	Player::getEnemyInstance().updateUnitPositions();
+
 	PlayerUpgrades::onFrame();
 	Player::getPlayerInstance().onFrame();
+
 
 	Player::getPlayerInstance().displayInfo(460);
 	Player::getEnemyInstance().displayInfo(560);
@@ -114,6 +118,12 @@ void AdditionalPylonsModule::onUnitDestroy(BWAPI::Unit unit) {
 }
 
 void AdditionalPylonsModule::onUnitMorph(BWAPI::Unit unit) {
+	// edge case: extractors only morph the underlying unit when they die and are created, so this can only be handled here
+	if (unit->getType() == BWAPI::UnitTypes::Resource_Vespene_Geyser) {
+		Player::getPlayerInstance().onUnitDestroy(unit);
+		Player::getEnemyInstance().onUnitDestroy(unit);
+	}
+
 	if (unit->getPlayer() == BWAPI::Broodwar->self()) {
 		Player::getPlayerInstance().onUnitMorph(unit);
 	}

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -4,11 +4,11 @@
 #include "../Strategist/Strategist.h"
 
 void Player::onStart(BWAPI::Race race) {
-    this->armyUnits.clear();
-    this->nonArmyUnits.clear();
-    this->buildingUnits.clear();
-    this->allUnits.clear();
-    this->playerRace = race;
+	this->armyUnits.clear();
+	this->nonArmyUnits.clear();
+	this->buildingUnits.clear();
+	this->allUnits.clear();
+	this->playerRace = race;
 }
 
 void Player::onFrame() {
@@ -18,30 +18,32 @@ void Player::onFrame() {
 	}
 	std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-    if (!armyUnits.empty()) {
-        BWAPI::Broodwar->drawTextScreen(0, 60, "Army time: %d ms", duration);
-        BWAPI::Broodwar->drawTextScreen(120, 60, "Per unit: %d ms", (duration / armyUnits.size()));
-    }
+	if (!armyUnits.empty()) {
+		BWAPI::Broodwar->drawTextScreen(0, 60, "Army time: %d ms", duration);
+		BWAPI::Broodwar->drawTextScreen(120, 60, "Per unit: %d ms", (duration / armyUnits.size()));
+	}
+
 	t1 = std::chrono::high_resolution_clock::now();
 	for (auto& [key, value] : this->nonArmyUnits) {
 		value->onFrame();
 	}
 	t2 = std::chrono::high_resolution_clock::now();
 	duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-    if (!nonArmyUnits.empty()) {
-        BWAPI::Broodwar->drawTextScreen(0, 70, "NonArmy time: %d ms", duration);
-        BWAPI::Broodwar->drawTextScreen(120, 70, "Per unit: %d ms", (duration / nonArmyUnits.size()));
-    }
+	if (!nonArmyUnits.empty()) {
+		BWAPI::Broodwar->drawTextScreen(0, 70, "NonArmy time: %d ms", duration);
+		BWAPI::Broodwar->drawTextScreen(120, 70, "Per unit: %d ms", (duration / nonArmyUnits.size()));
+	}
+
 	t1 = std::chrono::high_resolution_clock::now();
 	for (auto& [key, value] : this->buildingUnits) {
 		value->onFrame();
 	}
 	t2 = std::chrono::high_resolution_clock::now();
 	duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-    if (!buildingUnits.empty()) {
-        BWAPI::Broodwar->drawTextScreen(0, 80, "Building time: %d ms", duration);
-        BWAPI::Broodwar->drawTextScreen(120, 80, "Per unit: %d ms", (duration / buildingUnits.size()));
-    }
+	if (!buildingUnits.empty()) {
+		BWAPI::Broodwar->drawTextScreen(0, 80, "Building time: %d ms", duration);
+		BWAPI::Broodwar->drawTextScreen(120, 80, "Per unit: %d ms", (duration / buildingUnits.size()));
+	}
 }
 
 void Player::onNukeDetect(BWAPI::Position target) {
@@ -61,19 +63,19 @@ void Player::onUnitCreate(BWAPI::Unit unit) {
 	}
 
 	if (unit->getType().isBuilding()) {
-        auto area = BWEM::Map::Instance().GetArea(unit->getTilePosition());
-        if (area) {
-            if (buildingAreas.insert(area).second) {
-                for (auto& mineral : area->Minerals()) {
-                    allMinerals[mineral] = 0;
-                }
-                for (auto& geyser : area->Geysers()) {
-                    allGeysers[geyser] = 0;
-                }
-            }
-        }
-        this->buildingUnits[unit->getID()] = std::make_unique<BuildingWrapper>(BuildingWrapper(unit));
-    }
+		auto area = BWEM::Map::Instance().GetArea(unit->getTilePosition());
+		if (area) {
+			if (buildingAreas.insert(area).second) {
+				for (auto& mineral : area->Minerals()) {
+					allMinerals[mineral] = 0;
+				}
+				for (auto& geyser : area->Geysers()) {
+					allGeysers[geyser] = 0;
+				}
+			}
+		}
+		this->buildingUnits[unit->getID()] = std::make_unique<BuildingWrapper>(BuildingWrapper(unit));
+	}
 	else if (unit->getType().isWorker()) {
 		this->nonArmyUnits[unit->getID()] = std::make_unique<WorkerWrapper>(WorkerWrapper(unit));
 	}
@@ -92,9 +94,23 @@ void Player::onUnitCreate(BWAPI::Unit unit) {
 }
 
 void Player::onUnitDestroy(BWAPI::Unit unit) {
-    if (unit->getType().isBuilding()) {
-        this->buildingUnits.erase(unit->getID());
-    } else if (unit->getType().isWorker()) {
+	if (unit->getType().isBuilding()) {
+		auto wrapper = this->buildingUnits.find(unit->getID());
+		if (wrapper != this->buildingUnits.end()) {
+			bool areaStillOwned = false;
+			auto area = BWEM::Map::Instance().GetArea(wrapper->second->getTilePosition());
+			for (const auto& building : this->buildingUnits) {
+				if (BWEM::Map::Instance().GetArea(building.second->getTilePosition()) == area) {
+					areaStillOwned = true;
+				}
+			}
+			if (!areaStillOwned) {
+				this->buildingAreas.erase(area);
+			}
+		}
+
+		this->buildingUnits.erase(unit->getID());
+	} else if (unit->getType().isWorker()) {
 		auto unitIter = this->nonArmyUnits.find(unit->getID());
 		if(unitIter != nonArmyUnits.end()){
 			auto worker = static_cast<WorkerWrapper*>(unitIter->second.get());
@@ -105,20 +121,20 @@ void Player::onUnitDestroy(BWAPI::Unit unit) {
 		}
 		this->nonArmyUnits.erase(unit->getID());
 
-    } else if (unit->getType() == BWAPI::UnitTypes::Zerg_Larva || unit->getType() == BWAPI::UnitTypes::Zerg_Overlord) {
-        this->nonArmyUnits.erase(unit->getID());
-    } else {
-        this->armyUnits.erase(unit->getID());
-    }
-    this->allUnits.erase(unit->getID());
+	} else if (unit->getType() == BWAPI::UnitTypes::Zerg_Larva || unit->getType() == BWAPI::UnitTypes::Zerg_Overlord) {
+		this->nonArmyUnits.erase(unit->getID());
+	} else {
+		this->armyUnits.erase(unit->getID());
+	}
+	this->allUnits.erase(unit->getID());
 }
 
 void Player::onUnitMorph(BWAPI::Unit unit) {
-    this->buildingUnits.erase(unit->getID());
-    this->nonArmyUnits.erase(unit->getID());
-    this->armyUnits.erase(unit->getID());
-    this->allUnits.erase(unit->getID());
-    onUnitCreate(unit);
+	this->buildingUnits.erase(unit->getID());
+	this->nonArmyUnits.erase(unit->getID());
+	this->armyUnits.erase(unit->getID());
+	this->allUnits.erase(unit->getID());
+	onUnitCreate(unit);
 }
 
 void Player::onUnitRenegade(BWAPI::Unit unit) {
@@ -130,38 +146,31 @@ void Player::onUnitComplete(BWAPI::Unit unit) {
 void Player::onUnitDiscover(BWAPI::Unit unit) {
 }
 
-std::unordered_map<int, BWAPI::Unit> Player::getUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> predicate) {
-    std::unordered_map<int, BWAPI::Unit> units;
-    for (const auto& [key, value] : this->allUnits) {
-        if (predicate(value)) {
-            units[key] = value->getUnit();
-        }
-    }
-    return units;
+std::unordered_map<int, std::shared_ptr<UnitWrapper>> Player::getUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> predicate) {
+	std::unordered_map<int, std::shared_ptr<UnitWrapper>> units;
+	for (const auto& [key, value] : this->allUnits) {
+		if (predicate(value)) {
+			units[key] = value;
+		}
+	}
+	return units;
 }
 
 // Displays player info (race, # of units, # of buildings)
 void Player::displayInfo(int x) {
-    std::string race;
+	std::string race;
 
-    switch (this->playerRace) {
-        case BWAPI::Races::Enum::Protoss:
-            race = "Protoss";
-            break;
-        case BWAPI::Races::Enum::Terran:
-            race = "Terran";
-            break;
-        case BWAPI::Races::Enum::Zerg:
-            race = "Zerg";
-            break;
-        default:
-            race = "Unknown";
-            break;
-    }
+	switch (this->playerRace) {
+		case BWAPI::Races::Enum::Protoss: race = "Protoss"; break;
+		case BWAPI::Races::Enum::Terran: race = "Terran"; break;
+		case BWAPI::Races::Enum::Zerg: race = "Zerg"; break;
+		default: race = "Unknown"; break;
+	}
 
 	BWAPI::Broodwar->drawTextScreen(x, 50, "Race: %s", race.c_str());
 	BWAPI::Broodwar->drawTextScreen(x, 60, "Units: %d", this->armyUnits.size() + this->nonArmyUnits.size());
 	BWAPI::Broodwar->drawTextScreen(x, 70, "Buildings: %d", this->buildingUnits.size());
+	BWAPI::Broodwar->drawTextScreen(x, 80, "Areas: %d", this->buildingAreas.size());
 
 	for (auto& [key, value] : this->armyUnits) {
 		value->displayInfo();
@@ -174,18 +183,36 @@ void Player::displayInfo(int x) {
 	}
 }
 
-std::unordered_map<int, BWAPI::Unit> Player::getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight) {
-    std::unordered_map<int, BWAPI::Unit> areaUnits;
-    for (auto& [key, value] : this->allUnits) {
-        BWAPI::Position unitPos = value->getUnit()->getPosition();
-        if (((topLeft == unitPos) || (topLeft < unitPos)) &&
-            ((unitPos == botRight) || (unitPos < botRight)))
-            areaUnits[value->getID()] = value->getUnit();
-        else
-            continue;
-    }
+void Player::updateUnitPositions() {
+	for (auto& [key, value] : this->armyUnits) {
+		value->updatePosition();
+	}
 
-    return areaUnits;
+	for (auto& [key, value] : this->nonArmyUnits) {
+		value->updatePosition();
+	}
+
+	for (auto& [key, value] : this->buildingUnits) {
+		value->updatePosition();
+	}
+
+	for (auto& [key, value] : this->allUnits) {
+		value->updatePosition();
+	}
+}
+
+std::unordered_map<int, BWAPI::Unit> Player::getUnitsByArea(BWAPI::Position topLeft, BWAPI::Position botRight) {
+	std::unordered_map<int, BWAPI::Unit> areaUnits;
+	for (auto& [key, value] : this->allUnits) {
+		BWAPI::Position unitPos = value->getUnit()->getPosition();
+		if (((topLeft == unitPos) || (topLeft < unitPos)) &&
+			((unitPos == botRight) || (unitPos < botRight)))
+			areaUnits[value->getID()] = value->getUnit();
+		else
+			continue;
+	}
+
+	return areaUnits;
 }
 
 std::map<BWAPI::UnitType, int> Player::getUnitCount() {
@@ -201,75 +228,75 @@ std::map<BWAPI::UnitType, int> Player::getUnitCount() {
 }
 
 BWEM::Ressource* Player::getClosestGeyser(BWAPI::Position pos) {
-    return this->getClosestResource(pos, this->allGeysers);
+	return this->getClosestResource(pos, this->allGeysers);
 }
 
 BWEM::Ressource* Player::getClosestMineral(BWAPI::Position pos) {
-    return this->getClosestResource(pos, this->allMinerals);
+	return this->getClosestResource(pos, this->allMinerals);
 }
 
 // We iterate through both the known geysers and the known minerals.
 // sum up the amount of workers on each resource.
 // and return either their ratio of gas:minerals or FLOAT_MAX if there are no mineral workers
 float Player::getGasToMineralWorkerRatio() {
-    int totalGeyserWorkers = 0;
-    int totalMineralWorkers = 0;
-    for (auto& [key, value] : this->allGeysers) {
-        totalGeyserWorkers += value;
-    }
-    for (auto& [key, value] : this->allMinerals) {
-        totalMineralWorkers += value;
-    }
-    return totalMineralWorkers != 0 ? (float)totalGeyserWorkers / (float)totalMineralWorkers : std::numeric_limits<float>::max();
+	int totalGeyserWorkers = 0;
+	int totalMineralWorkers = 0;
+	for (auto& [key, value] : this->allGeysers) {
+		totalGeyserWorkers += value;
+	}
+	for (auto& [key, value] : this->allMinerals) {
+		totalMineralWorkers += value;
+	}
+	return totalMineralWorkers != 0 ? (float)totalGeyserWorkers / (float)totalMineralWorkers : std::numeric_limits<float>::max();
 }
 
 // We determine if a given resource is a mineralfield or a geyser.
 // If we can find the resource in our resource maps, adjust the worker count for that resource
 void Player::adjustResourceWorkerCount(BWEM::Ressource* res, int val) {
-    if (res->Unit()->getType().isMineralField()) {
-        auto mineralIter = allMinerals.find(res);
-        if(mineralIter != allMinerals.end()) {
-            mineralIter->second += val;
-        }
-    } else {
-        auto geyserIter = allGeysers.find(res);
-        if(geyserIter != allGeysers.end()) {
-            geyserIter->second += val;
-        }
+	if (res->Unit()->getType().isMineralField()) {
+		auto mineralIter = allMinerals.find(res);
+		if(mineralIter != allMinerals.end()) {
+			mineralIter->second += val;
+		}
+	} else {
+		auto geyserIter = allGeysers.find(res);
+		if(geyserIter != allGeysers.end()) {
+			geyserIter->second += val;
+		}
 	}
 }
 
 BWEM::Ressource* Player::getClosestResource(BWAPI::Position pos, const std::map<BWEM::Ressource*, int>& resources) {
-    BWEM::Ressource* closest = nullptr;
-    size_t closestDistance = SIZE_MAX;
+	BWEM::Ressource* closest = nullptr;
+	size_t closestDistance = SIZE_MAX;
 
-    for (auto& [key, value] : resources) {
-        if (value >= 3)
-            continue;
-        auto path = BWEB::Path(pos, key->Pos(), BWAPI::UnitTypes::Zerg_Drone);
-        path.generateJPS([&](const BWAPI::TilePosition& pos) {
-            BWAPI::WalkPosition walkPos = BWAPI::WalkPosition(pos);
-            for (int i = 0; i < (BWAPI::TILEPOSITION_SCALE / BWAPI::WALKPOSITION_SCALE); i++) {
-                walkPos = BWAPI::WalkPosition(walkPos.x + (i % 2), walkPos.y + (i / 2));
-                if (!BWAPI::Broodwar->isWalkable(walkPos))
-                    return false;
-            }
-             return true;
-        });
-        if(path.isReachable() && path.getTiles().size() < closestDistance) {
-            closest = key;
-            closestDistance = path.getTiles().size();
-        }
-    }
-    return closest;
+	for (auto& [key, value] : resources) {
+		if (value >= 3)
+			continue;
+		auto path = BWEB::Path(pos, key->Pos(), BWAPI::UnitTypes::Zerg_Drone);
+		path.generateJPS([&](const BWAPI::TilePosition& pos) {
+			BWAPI::WalkPosition walkPos = BWAPI::WalkPosition(pos);
+			for (int i = 0; i < (BWAPI::TILEPOSITION_SCALE / BWAPI::WALKPOSITION_SCALE); i++) {
+				walkPos = BWAPI::WalkPosition(walkPos.x + (i % 2), walkPos.y + (i / 2));
+				if (!BWAPI::Broodwar->isWalkable(walkPos))
+					return false;
+			}
+			 return true;
+		});
+		if(path.isReachable() && path.getTiles().size() < closestDistance) {
+			closest = key;
+			closestDistance = path.getTiles().size();
+		}
+	}
+	return closest;
 }
 
 namespace PlayerUpgrades {
 	std::map<BWAPI::Player, std::shared_ptr<Upgrades>> playerUpgradesMap;
 
-    void onStart() {
-        playerUpgradesMap.clear();
-    }
+	void onStart() {
+		playerUpgradesMap.clear();
+	}
 
 	void onFrame() {
 		for (const auto& playerUpgrades : playerUpgradesMap)

--- a/src/Players/Player.cpp
+++ b/src/Players/Player.cpp
@@ -100,6 +100,8 @@ void Player::onUnitDestroy(BWAPI::Unit unit) {
 			bool areaStillOwned = false;
 			auto area = BWEM::Map::Instance().GetArea(wrapper->second->getTilePosition());
 			for (const auto& building : this->buildingUnits) {
+				// ignore the building being destroyed
+				if (building.first == wrapper->first) continue;
 				if (BWEM::Map::Instance().GetArea(building.second->getTilePosition()) == area) {
 					areaStillOwned = true;
 				}

--- a/src/Players/Player.h
+++ b/src/Players/Player.h
@@ -51,6 +51,8 @@ public:
     BWAPI::Race getRace() { return this->playerRace; }
     void displayInfo(int x);
 
+    void updateUnitPositions();
+
     /*
     Returns a map of all units in a specified area
     @returns
@@ -64,7 +66,7 @@ public:
     @returns
         @retval std::unordered_map<int, BWAPI::Unit> map of units
     */
-    std::unordered_map<int, BWAPI::Unit> getUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> predicate);
+    std::unordered_map<int, std::shared_ptr<UnitWrapper>> getUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> predicate);
 
     /*
     Returns a map of count of each BWAPI::UnitType owned by the player

--- a/src/Units/ArmyWrappers/ArmyWrapper.cpp
+++ b/src/Units/ArmyWrappers/ArmyWrapper.cpp
@@ -1,0 +1,10 @@
+#include "./ArmyWrapper.h"
+
+#include "../../Players/Player.h"
+
+std::vector<std::shared_ptr<UnitWrapper>> ArmyWrapper::getListOfEnemyUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> filterPredicate) {
+    std::vector<std::shared_ptr<UnitWrapper>> vectorUnits;
+    auto units = Player::getEnemyInstance().getUnitsByPredicate(filterPredicate);
+	std::transform(units.begin(), units.end(), std::back_inserter(vectorUnits), [](auto& keyvalue) { return keyvalue.second; });
+    return vectorUnits;
+}

--- a/src/Units/ArmyWrappers/ArmyWrapper.h
+++ b/src/Units/ArmyWrappers/ArmyWrapper.h
@@ -5,6 +5,9 @@ class ArmyWrapper : public UnitWrapper {
 public:
 	ArmyWrapper(BWAPI::Unit u) : UnitWrapper(u) {};
 	~ArmyWrapper() = default;
+
 protected:
+	std::vector<std::shared_ptr<UnitWrapper>> getListOfEnemyUnitsByPredicate(std::function <bool(const std::shared_ptr<UnitWrapper>)> filterPredicate);
+
 	BWAPI::TilePosition scoutLocation = BWAPI::TilePositions::Invalid;
 };

--- a/src/Units/ArmyWrappers/HydraliskWrapper.cpp
+++ b/src/Units/ArmyWrappers/HydraliskWrapper.cpp
@@ -37,9 +37,9 @@ void HydraliskWrapper::handleScoutStrategy() {
 	}
 
 	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
-	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-		this->unit->move(BWAPI::Position(this->scoutLocation));
-	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+	if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation), true);
+	} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
 		if (this->scoutLocation.isValid()) {
 			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
 				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
@@ -55,5 +55,5 @@ void HydraliskWrapper::handleAttackStrategy() {
 }
 
 void HydraliskWrapper::handleDefenseStrategy() {
-	
+
 }

--- a/src/Units/ArmyWrappers/HydraliskWrapper.cpp
+++ b/src/Units/ArmyWrappers/HydraliskWrapper.cpp
@@ -1,6 +1,22 @@
 #include "./HydraliskWrapper.h"
 
-void HydraliskWrapper::onFrame() {}
+#include <bwem.h>
+
+#include "../../Strategist/Strategist.h"
+#include "../../Strategist/ScoutEngine/ScoutEngine.h"
+#include "../../Players/Player.h"
+#include "../../Lambdas/Map/MapLambdas.h"
+
+void HydraliskWrapper::onFrame() {
+    if (!this->unit->isCompleted()) return;
+
+	switch(Strategist::getInstance().getPlayDecision()) {
+	case PlayDecision::scout: this->handleScoutStrategy(); break;
+	case PlayDecision::attack: this->handleAttackStrategy(); break;
+	case PlayDecision::defend: this->handleDefenseStrategy(); break;
+	case PlayDecision::none: this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation())); break;
+	}
+}
 
 void HydraliskWrapper::displayInfo() {
     if (this->unit->getLastCommand().getTarget()) {
@@ -12,4 +28,32 @@ void HydraliskWrapper::displayInfo() {
     else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
         BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
     }
+}
+
+void HydraliskWrapper::handleScoutStrategy() {
+	// check if we currently have a base to scout
+	if (!this->scoutLocation.isValid()) {
+		this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	}
+
+	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
+	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation));
+	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+		if (this->scoutLocation.isValid()) {
+			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
+				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
+					Player::getEnemyInstance().getBuildingAreas().end()) {
+				this->scoutLocation = BWAPI::TilePositions::Invalid;
+			}
+		}
+	}
+}
+
+void HydraliskWrapper::handleAttackStrategy() {
+
+}
+
+void HydraliskWrapper::handleDefenseStrategy() {
+	
 }

--- a/src/Units/ArmyWrappers/HydraliskWrapper.h
+++ b/src/Units/ArmyWrappers/HydraliskWrapper.h
@@ -8,4 +8,9 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
+
+protected:
+    void handleScoutStrategy();
+    void handleAttackStrategy();
+    void handleDefenseStrategy();
 };

--- a/src/Units/ArmyWrappers/LurkerWrapper.cpp
+++ b/src/Units/ArmyWrappers/LurkerWrapper.cpp
@@ -37,9 +37,9 @@ void LurkerWrapper::handleScoutStrategy() {
 	}
 
 	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
-	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-		this->unit->move(BWAPI::Position(this->scoutLocation));
-	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+	if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation), true);
+	} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
 		if (this->scoutLocation.isValid()) {
 			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
 				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==

--- a/src/Units/ArmyWrappers/LurkerWrapper.cpp
+++ b/src/Units/ArmyWrappers/LurkerWrapper.cpp
@@ -1,6 +1,22 @@
 #include "./LurkerWrapper.h"
 
-void LurkerWrapper::onFrame() {}
+#include <bwem.h>
+
+#include "../../Strategist/Strategist.h"
+#include "../../Strategist/ScoutEngine/ScoutEngine.h"
+#include "../../Players/Player.h"
+#include "../../Lambdas/Map/MapLambdas.h"
+
+void LurkerWrapper::onFrame() {
+    if (!this->unit->isCompleted()) return;
+
+	switch(Strategist::getInstance().getPlayDecision()) {
+	case PlayDecision::scout: this->handleScoutStrategy(); break;
+	case PlayDecision::attack: this->handleAttackStrategy(); break;
+	case PlayDecision::defend: this->handleDefenseStrategy(); break;
+	case PlayDecision::none: this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation())); break;
+	}
+}
 
 void LurkerWrapper::displayInfo() {
     if (this->unit->getLastCommand().getTarget()) {
@@ -12,4 +28,32 @@ void LurkerWrapper::displayInfo() {
     else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
         BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
     }
+}
+
+void LurkerWrapper::handleScoutStrategy() {
+	// check if we currently have a base to scout
+	if (!this->scoutLocation.isValid()) {
+		this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	}
+
+	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
+	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation));
+	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+		if (this->scoutLocation.isValid()) {
+			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
+				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
+					Player::getEnemyInstance().getBuildingAreas().end()) {
+				this->scoutLocation = BWAPI::TilePositions::Invalid;
+			}
+		}
+	}
+}
+
+void LurkerWrapper::handleAttackStrategy() {
+
+}
+
+void LurkerWrapper::handleDefenseStrategy() {
+	
 }

--- a/src/Units/ArmyWrappers/LurkerWrapper.h
+++ b/src/Units/ArmyWrappers/LurkerWrapper.h
@@ -8,4 +8,9 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
+
+protected:
+    void handleScoutStrategy();
+    void handleAttackStrategy();
+    void handleDefenseStrategy();
 };

--- a/src/Units/ArmyWrappers/MustaliskWrapper.cpp
+++ b/src/Units/ArmyWrappers/MustaliskWrapper.cpp
@@ -37,9 +37,9 @@ void MutaliskWrapper::handleScoutStrategy() {
 	}
 
 	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
-	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-		this->unit->move(BWAPI::Position(this->scoutLocation));
-	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+	if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation), true);
+	} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
 		if (this->scoutLocation.isValid()) {
 			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
 				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==

--- a/src/Units/ArmyWrappers/MustaliskWrapper.cpp
+++ b/src/Units/ArmyWrappers/MustaliskWrapper.cpp
@@ -1,6 +1,22 @@
 #include "./MutaliskWrapper.h"
 
-void MutaliskWrapper::onFrame() {}
+#include <bwem.h>
+
+#include "../../Strategist/Strategist.h"
+#include "../../Strategist/ScoutEngine/ScoutEngine.h"
+#include "../../Players/Player.h"
+#include "../../Lambdas/Map/MapLambdas.h"
+
+void MutaliskWrapper::onFrame() {
+    if (!this->unit->isCompleted()) return;
+
+	switch(Strategist::getInstance().getPlayDecision()) {
+	case PlayDecision::scout: this->handleScoutStrategy(); break;
+	case PlayDecision::attack: this->handleAttackStrategy(); break;
+	case PlayDecision::defend: this->handleDefenseStrategy(); break;
+	case PlayDecision::none: this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation())); break;
+	}
+}
 
 void MutaliskWrapper::displayInfo() {
     if (this->unit->getLastCommand().getTarget()) {
@@ -12,4 +28,32 @@ void MutaliskWrapper::displayInfo() {
     else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
         BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
     }
+}
+
+void MutaliskWrapper::handleScoutStrategy() {
+	// check if we currently have a base to scout
+	if (!this->scoutLocation.isValid()) {
+		this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	}
+
+	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
+	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation));
+	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+		if (this->scoutLocation.isValid()) {
+			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
+				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
+					Player::getEnemyInstance().getBuildingAreas().end()) {
+				this->scoutLocation = BWAPI::TilePositions::Invalid;
+			}
+		}
+	}
+}
+
+void MutaliskWrapper::handleAttackStrategy() {
+
+}
+
+void MutaliskWrapper::handleDefenseStrategy() {
+	
 }

--- a/src/Units/ArmyWrappers/MutaliskWrapper.h
+++ b/src/Units/ArmyWrappers/MutaliskWrapper.h
@@ -8,4 +8,9 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
+
+protected:
+    void handleScoutStrategy();
+    void handleAttackStrategy();
+    void handleDefenseStrategy();
 };

--- a/src/Units/ArmyWrappers/ZerglingWrapper.cpp
+++ b/src/Units/ArmyWrappers/ZerglingWrapper.cpp
@@ -43,9 +43,9 @@ void ZerglingWrapper::handleScoutStrategy() {
 	}
 
 	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
-	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-		this->unit->move(BWAPI::Position(this->scoutLocation));
-	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+	if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation), true);
+	} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
 		if (this->scoutLocation.isValid()) {
 			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
 				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==

--- a/src/Units/ArmyWrappers/ZerglingWrapper.cpp
+++ b/src/Units/ArmyWrappers/ZerglingWrapper.cpp
@@ -2,7 +2,9 @@
 
 #include <unordered_map>
 #include <iterator>
+#include <limits>
 
+#include <bwem.h>
 #include <BWEB.h>
 
 #include "../../Strategist/Strategist.h"
@@ -14,48 +16,81 @@
 void ZerglingWrapper::onFrame() {
 	if (!this->unit->isCompleted()) return;
 
-	std::unordered_map<int, BWAPI::Unit> units;
-	std::vector<BWAPI::Unit> vectorUnits;
+	switch(Strategist::getInstance().getPlayDecision()) {
+	case PlayDecision::scout: this->handleScoutStrategy(); break;
+	case PlayDecision::attack: this->handleAttackStrategy(); break;
+	case PlayDecision::defend: this->handleDefenseStrategy(); break;
+	case PlayDecision::none: this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation())); break;
+	}
+}
+
+void ZerglingWrapper::displayInfo() {
+    if (this->unit->getLastCommand().getTarget()) {
+        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTarget()->getPosition(), BWAPI::Colors::White);
+    }
+    else if (this->unit->getLastCommand().getTargetPosition().isValid()) {
+        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTargetPosition(), BWAPI::Colors::White);
+    }
+    else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
+        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
+    }
+}
+
+void ZerglingWrapper::handleScoutStrategy() {
+	// check if we currently have a base to scout
+	if (!this->scoutLocation.isValid()) {
+		this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	}
+
+	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
+	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation));
+	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+		if (this->scoutLocation.isValid()) {
+			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
+				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
+					Player::getEnemyInstance().getBuildingAreas().end()) {
+				this->scoutLocation = BWAPI::TilePositions::Invalid;
+			}
+		}
+	}
+}
+
+void ZerglingWrapper::handleAttackStrategy() {
+	std::vector<std::shared_ptr<UnitWrapper>> vectorUnits;
 	std::set<const BWEM::Area*> areas;
 	std::vector<const BWEM::Area*> vectorAreas;
 
-	switch(Strategist::getInstance().getPlayDecision()) {
-	case PlayDecision::scout:
-		if (!this->scoutLocation.isValid()) {
-			this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	// grab all the visible units owned by the enemy, convert to a vector of BWAPI::Unit, and sort by priority
+	vectorUnits = this->getListOfEnemyUnitsByPredicate(lambdas::unit::getAllVisibleUnitsLambda);
+	std::sort(vectorUnits.begin(), vectorUnits.end(), [this](const std::shared_ptr<UnitWrapper>& a, const std::shared_ptr<UnitWrapper>& b) -> bool {
+		auto aCanAttack = a->getUnitType().canAttack(), bCanAttack = b->getUnitType().canAttack();
+		if (aCanAttack == bCanAttack) {
+			return this->unit->getDistance(a->getPosition()) < this->unit->getDistance(b->getPosition());
 		}
-		if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-			this->unit->move(BWAPI::Position(this->scoutLocation), true);
-		} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
-			if (this->scoutLocation.isValid()) {
-				if (Player::getEnemyInstance().getBuildingAreas().empty() ||
-					Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
-						Player::getEnemyInstance().getBuildingAreas().end()) {
-					this->scoutLocation = BWAPI::TilePositions::Invalid;
-				}
+		else {
+			return aCanAttack > bCanAttack;
+		}
+	});
+	
+	// check if we have units to go to, if not, grab the enemy areas
+	if (!vectorUnits.empty()) {
+		if (this->unit->getLastCommand().getTarget() != vectorUnits.front()->getUnit()) {
+			if (this->unit->getTarget() != vectorUnits.front()->getUnit()) {
+				this->unit->attack(vectorUnits.front()->getUnit());
 			}
 		}
-		break;
-
-	case PlayDecision::attack:
-		units = Player::getEnemyInstance().getUnitsByPredicate(lambdas::unit::getAllVisibleUnitsLambda);
-		std::transform(units.begin(), units.end(), std::back_inserter(vectorUnits), [](auto& keyvalue) { return keyvalue.second; });
-		std::sort(vectorUnits.begin(), vectorUnits.end(), [this](const BWAPI::Unit& a, const BWAPI::Unit& b) -> bool {
-			auto aCanAttack = a->getType().canAttack(), bCanAttack = b->getType().canAttack();
-			if (aCanAttack == bCanAttack) {
-				return this->unit->getDistance(a) < this->unit->getDistance(b);
-			} else {
-				return aCanAttack > bCanAttack;
-			}
+	} else {
+		// check if there are any buildings associated with the enemy, sort by priority
+		vectorUnits = this->getListOfEnemyUnitsByPredicate(lambdas::unit::getBuildingsLambda);
+		std::sort(vectorUnits.begin(), vectorUnits.end(), [this](const std::shared_ptr<UnitWrapper>& a, const std::shared_ptr<UnitWrapper>& b) -> bool {
+				return this->unit->getDistance(a->getPosition()) < this->unit->getDistance(b->getPosition());
 		});
-		
-		if (vectorUnits.size()) {
-			if (this->unit->getLastCommand().getTarget() != vectorUnits.at(0)) {
-				if (this->unit->getTarget() != vectorUnits.at(0)) {
-					this->unit->attack(vectorUnits.at(0));
-				}
-			}
+
+		if (!vectorUnits.empty()) {
+			this->unit->move(vectorUnits.front()->getPosition());
 		} else {
+			// grab enemy areas, convert to a vector, and sort by distance
 			areas = Player::getEnemyInstance().getBuildingAreas();
 			std::transform(areas.begin(), areas.end(), std::back_inserter(vectorAreas), [](auto& keyvalue) { return keyvalue; });
 			std::sort(vectorAreas.begin(), vectorAreas.end(), [this](const BWEM::Area* a, const BWEM::Area* b) -> bool {
@@ -63,7 +98,8 @@ void ZerglingWrapper::onFrame() {
 				return this->unit->getDistance(BWAPI::Position(aCenter)) < this->unit->getDistance(BWAPI::Position(bCenter));
 			});
 
-			if (vectorAreas.size()) {
+			// if the area vector isn't empty, we have a base to go to
+			if (!vectorAreas.empty()) {
 				bool foundUnexploredBase = false;
 				for (const auto& area : vectorAreas) {
 					for (const auto& base : area->Bases()) {
@@ -81,23 +117,9 @@ void ZerglingWrapper::onFrame() {
 				}
 			}
 		}
-		break;
-	case PlayDecision::defend:
-		break;
-	case PlayDecision::none:
-		this->unit->move(BWAPI::Position(BWAPI::Broodwar->self()->getStartLocation()));
-		break;
 	}
 }
 
-void ZerglingWrapper::displayInfo() {
-    if (this->unit->getLastCommand().getTarget()) {
-        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTarget()->getPosition(), BWAPI::Colors::White);
-    }
-    else if (this->unit->getLastCommand().getTargetPosition().isValid()) {
-        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTargetPosition(), BWAPI::Colors::White);
-    }
-    else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
-        BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
-    }
+void ZerglingWrapper::handleDefenseStrategy() {
+
 }

--- a/src/Units/ArmyWrappers/ZerglingWrapper.h
+++ b/src/Units/ArmyWrappers/ZerglingWrapper.h
@@ -8,4 +8,9 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
+
+protected:
+    void handleScoutStrategy();
+    void handleAttackStrategy();
+    void handleDefenseStrategy();
 };

--- a/src/Units/NonArmyWrappers/OverlordWrapper.cpp
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.cpp
@@ -5,6 +5,7 @@
 #include "../../Strategist/Strategist.h"
 #include "../../Strategist/ScoutEngine/ScoutEngine.h"
 #include "../../Players/Player.h"
+#include "../../Lambdas/Map/MapLambdas.h"
 
 void OverlordWrapper::onFrame() {
 	if (!this->unit->isCompleted()) return;
@@ -12,19 +13,7 @@ void OverlordWrapper::onFrame() {
 	auto enemyAreas = Player::getEnemyInstance().getBuildingAreas();
 
 	switch(Strategist::getInstance().getPlayDecision()) {
-	case PlayDecision::scout:
-		if (!this->scoutLocation.isValid()) {
-			this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
-		}
-		if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-			this->unit->move(BWAPI::Position(this->scoutLocation));
-		} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
-			// only reset the scout's location if they aren't an enemy base
-			if (enemyAreas.empty() || (enemyAreas.find(BWEM::Map::Instance().GetArea(this->scoutLocation)) == enemyAreas.end())) {
-				this->scoutLocation = BWAPI::TilePositions::Invalid;
-			}
-		}
-		break;
+	case PlayDecision::scout: this->handleScoutStrategy(); break;
 	case PlayDecision::attack:
 		[[fallthrough]];
 	case PlayDecision::defend:
@@ -40,7 +29,7 @@ void OverlordWrapper::onFrame() {
 }
 
 void OverlordWrapper::displayInfo() {
-    if (this->unit->getLastCommand().getTarget()) {
+	if (this->unit->getLastCommand().getTarget()) {
         BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), this->unit->getLastCommand().getTarget()->getPosition(), BWAPI::Colors::White);
     }
     else if (this->unit->getLastCommand().getTargetPosition().isValid()) {
@@ -49,4 +38,24 @@ void OverlordWrapper::displayInfo() {
     else if (this->unit->getLastCommand().getTargetTilePosition().isValid()) {
         BWAPI::Broodwar->drawLineMap(this->unit->getPosition(), BWAPI::Position(this->unit->getLastCommand().getTargetTilePosition()), BWAPI::Colors::White);
     }
+}
+
+void OverlordWrapper::handleScoutStrategy() {
+	// check if we currently have a base to scout
+	if (!this->scoutLocation.isValid()) {
+		this->scoutLocation = ScoutEngine::getInstance().getNextBaseToScout();
+	}
+
+	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
+	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation));
+	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+		if (this->scoutLocation.isValid()) {
+			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
+				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==
+					Player::getEnemyInstance().getBuildingAreas().end()) {
+				this->scoutLocation = BWAPI::TilePositions::Invalid;
+			}
+		}
+	}
 }

--- a/src/Units/NonArmyWrappers/OverlordWrapper.cpp
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.cpp
@@ -47,9 +47,9 @@ void OverlordWrapper::handleScoutStrategy() {
 	}
 
 	// if we aren't at the scout location and we did not issue an order to go that location, issue the command
-	if (this->scoutLocation != this->unit->getTilePosition() && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
-		this->unit->move(BWAPI::Position(this->scoutLocation));
-	} else if (this->scoutLocation == this->unit->getTilePosition()) {
+	if (!BWAPI::Broodwar->isVisible(this->scoutLocation) && this->unit->getTargetPosition() != BWAPI::Position(this->scoutLocation)) {
+		this->unit->move(BWAPI::Position(this->scoutLocation), true);
+	} else if (BWAPI::Broodwar->isVisible(this->scoutLocation)) {
 		if (this->scoutLocation.isValid()) {
 			if (Player::getEnemyInstance().getBuildingAreas().empty() ||
 				Player::getEnemyInstance().getBuildingAreas().find(BWEM::Map::Instance().GetArea(this->scoutLocation)) ==

--- a/src/Units/NonArmyWrappers/OverlordWrapper.h
+++ b/src/Units/NonArmyWrappers/OverlordWrapper.h
@@ -10,6 +10,9 @@ public:
 
     void onFrame() override;
     void displayInfo() override;
-private:
+
+protected:
+    void handleScoutStrategy();
+    
     BWAPI::TilePosition scoutLocation = BWAPI::TilePositions::Invalid;
 };

--- a/src/Units/UnitWrapper.h
+++ b/src/Units/UnitWrapper.h
@@ -11,6 +11,15 @@ public:
     BWAPI::UnitType getUnitType() { return this->type; }
     int getID() { return this->unitID; }
 
+    virtual const BWAPI::Position& getPosition() { return this->pos; }
+    virtual const BWAPI::TilePosition& getTilePosition() { return this->tilePos; }
+    virtual void updatePosition() {
+        if (this->unit->isVisible(BWAPI::Broodwar->self()) && this->unit->getPosition().isValid()) {
+            this->pos = this->unit->getPosition();
+            this->tilePos = this->unit->getTilePosition();
+        }
+    }
+
     virtual bool isBusy() {
         if (!this->unit->isCompleted() ||
             this->unit->isCarryingMinerals() ||
@@ -22,9 +31,16 @@ public:
         return false;
     }
     virtual void onFrame() {}
-    virtual void displayInfo() { BWAPI::Broodwar->drawTextMap(this->unit->getPosition(), "UnitWrapper"); }
+    virtual void displayInfo() {}
+    
 
 protected:
+    virtual void handleScoutStrategy() {};
+	virtual void handleAttackStrategy() {};
+	virtual void handleDefenseStrategy() {};
+
+    BWAPI::Position pos = BWAPI::Positions::Invalid;
+    BWAPI::TilePosition tilePos = BWAPI::TilePositions::Invalid;
     std::queue<BWAPI::TilePosition> queue;
     int unitID;
     BWAPI::Unit unit;

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp" />
     <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
+    <ClCompile Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\MustaliskWrapper.cpp" />

--- a/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
+++ b/vs/AdditionalPylons/AdditionalPylons.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="..\..\src\Dll.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.cpp">
+      <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="..\..\src\Strategist\ScoutEngine\ScoutEngine.cpp" />
     <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp" />
     <ClCompile Include="..\..\src\Strategist\Strategist.cpp" />
+    <ClCompile Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\HydraliskWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\LurkerWrapper.cpp" />
     <ClCompile Include="..\..\src\Units\ArmyWrappers\MustaliskWrapper.cpp" />

--- a/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
+++ b/vs/AdditionalPylons_client/AdditionalPylons_client.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="..\..\src\Players\Upgrades\Upgrades.cpp">
       <Filter>Source Files\Players\Upgrades</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Units\ArmyWrappers\ArmyWrapper.cpp">
+      <Filter>Source Files\Units\ArmyWrappers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AdditionalPylonsModule.h">


### PR DESCRIPTION
* fixed issue where enemy gas extractors caused units to hang
* fixed issue where associated player areas were not removed when all buildings in the area are destroyed
* restructured wrapper functionality to separate methods for each strategist play decision
* added functionality to the UnitWrapper to store the unit's position and tile position
* added onFrame and scouting functionality to remaining unit wrappers
* adjusted Zergling attack strategy to account for enemy buildings that aren't currently visible

testing:
* just test against the above issues